### PR TITLE
UA on old initial capz cluster

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+helm/cluster-azure/charts

--- a/helm/cluster-azure/Chart.yaml
+++ b/helm/cluster-azure/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: cluster-azure
-description: A helm chart for creating Cluster API clusters with the Azure infrastructure provider (CAPA).
+description: A helm chart for creating Cluster API clusters with the Azure infrastructure provider (CAPZ).
 type: application
 version: [[ .Version ]]
 annotations:

--- a/helm/cluster-azure/templates/_azure_cluster.tpl
+++ b/helm/cluster-azure/templates/_azure_cluster.tpl
@@ -1,0 +1,27 @@
+{{- define "azure-cluster" }}
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: AzureCluster
+metadata:
+  labels:
+    {{- include "labels.common" $ | nindent 4 }}
+  name: {{ include "resource.default.name" $ }}
+  namespace: {{ .Release.Namespace }}
+spec:
+  identityRef:
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    kind: AzureClusterIdentity
+    name: cluster-identity
+  location: {{ .Values.azure.location }}
+  networkSpec:
+    subnets:
+      - name: control-plane-subnet
+        role: control-plane
+      - name: node-subnet
+        natGateway:
+          name: node-natgateway
+        role: node
+    vnet:
+      name: {{ include "resource.default.name" $ }}-vnet
+  resourceGroup: {{ include "resource.default.name" $ }}
+  subscriptionID: {{ .Values.azure.subsciptionID }}
+{{ end }}

--- a/helm/cluster-azure/templates/_cluster.tpl
+++ b/helm/cluster-azure/templates/_cluster.tpl
@@ -12,6 +12,9 @@ metadata:
   namespace: {{ .Release.Namespace }}
 spec:
   clusterNetwork:
+    services:
+      cidrBlocks:
+       - {{ .Values.network.serviceCIDR }}
     pods:
       cidrBlocks:
       - {{ .Values.network.podCIDR }}

--- a/helm/cluster-azure/templates/_cluster.tpl
+++ b/helm/cluster-azure/templates/_cluster.tpl
@@ -5,6 +5,7 @@ metadata:
   annotations:
     cluster.giantswarm.io/description: "{{ .Values.clusterDescription }}"
   labels:
+    cni: calico
     cluster-apps-operator.giantswarm.io/watching: ""
     {{- include "labels.common" $ | nindent 4 }}
   name: {{ include "resource.default.name" $ }}

--- a/helm/cluster-azure/templates/_helpers.tpl
+++ b/helm/cluster-azure/templates/_helpers.tpl
@@ -40,6 +40,11 @@ room for such suffix.
 {{- end -}}
 
 
+{{/*Helper to define per cluster User Assigned Identity prefix*/}}
+{{- define "vmUaIdentityPrefix" -}}
+/subscriptions/{{ .Values.azureCloud.subscriptionId }}/resourceGroups/{{ include "resource.default.name" . }}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{{ include "resource.default.name" . }}
+{{- end -}}
+
 {{- define "sshFiles" -}}
 - path: /etc/ssh/trusted-user-ca-keys.pem
   permissions: "0600"

--- a/helm/cluster-azure/templates/_helpers.tpl
+++ b/helm/cluster-azure/templates/_helpers.tpl
@@ -22,7 +22,6 @@ app: {{ include "name" . | quote }}
 app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 cluster.x-k8s.io/cluster-name: {{ include "resource.default.name" . | quote }}
-cluster.x-k8s.io/watch-filter: capi
 giantswarm.io/cluster: {{ include "resource.default.name" . | quote }}
 giantswarm.io/organization: {{ .Values.organization | quote }}
 helm.sh/chart: {{ include "chart" . | quote }}

--- a/helm/cluster-azure/templates/_helpers.tpl
+++ b/helm/cluster-azure/templates/_helpers.tpl
@@ -42,7 +42,7 @@ room for such suffix.
 
 {{/*Helper to define per cluster User Assigned Identity prefix*/}}
 {{- define "vmUaIdentityPrefix" -}}
-/subscriptions/{{ .Values.azureCloud.subscriptionId }}/resourceGroups/{{ include "resource.default.name" . }}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{{ include "resource.default.name" . }}
+/subscriptions/{{ .Values.azure.subscriptionId }}/resourceGroups/{{ include "resource.default.name" . }}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{{ include "resource.default.name" . }}
 {{- end -}}
 
 {{- define "sshFiles" -}}

--- a/helm/cluster-azure/templates/_kcp.tpl
+++ b/helm/cluster-azure/templates/_kcp.tpl
@@ -1,0 +1,110 @@
+{{- define "control-plane" }}
+apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+kind: KubeadmControlPlane
+metadata:
+  labels:
+    {{- include "labels.common" $ | nindent 4 }}
+  name: {{ include "resource.default.name" $ }}
+  namespace: {{ $.Release.Namespace }}
+spec:
+  machineTemplate:
+    metadata:
+      labels:
+        {{- include "labels.common" $ | nindent 8 }}
+    infrastructureRef:
+      apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+      kind: AzureMachineTemplate
+      name: {{ include "resource.default.name" $ }}-control-plane
+  kubeadmConfigSpec:
+    clusterConfiguration:
+      apiServer:
+        extraArgs:
+          cloud-provider: external
+          encryption-provider-config: /etc/kubernetes/encryption/config.yaml
+          enable-admission-plugins: NamespaceLifecycle,LimitRanger,ServiceAccount,ResourceQuota,DefaultStorageClass,PersistentVolumeClaimResize,Priority,DefaultTolerationSeconds,MutatingAdmissionWebhook,ValidatingAdmissionWebhook,PodSecurityPolicy
+          feature-gates: TTLAfterFinished=true
+          kubelet-preferred-address-types: InternalIP
+          profiling: "false"
+          requestheader-allowed-names: "front-proxy-client"
+          runtime-config: api/all=true
+          service-account-lookup: "true"
+          tls-cipher-suites: "TLS_AES_128_GCM_SHA256,TLS_AES_256_GCM_SHA384,TLS_CHACHA20_POLY1305_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256,TLS_RSA_WITH_AES_128_CBC_SHA,TLS_RSA_WITH_AES_128_GCM_SHA256,TLS_RSA_WITH_AES_256_CBC_SHA,TLS_RSA_WITH_AES_256_GCM_SHA384"
+          service-cluster-ip-range: {{ .Values.network.serviceCIDR }}
+        extraVolumes:
+        - name: encryption
+          hostPath: /etc/kubernetes/encryption
+          mountPath: /etc/kubernetes/encryption
+          readOnly: false
+          pathType: DirectoryOrCreate
+      controllerManager:
+        extraArgs:
+          authorization-always-allow-paths: "/healthz,/readyz,/livez,/metrics"
+          bind-address: "0.0.0.0"
+          cloud-provider: external
+          feature-gates: "TTLAfterFinished=true"
+          logtostderr: "true"
+          profiling: "false"
+      scheduler:
+        extraArgs:
+          authorization-always-allow-paths: "/healthz,/readyz,/livez,/metrics"
+          bind-address: "0.0.0.0"
+      etcd:
+        local:
+          dataDir: /var/lib/etcddisk/etcd
+          extraArgs:
+            listen-metrics-urls: "http://0.0.0.0:2381"
+            quota-backend-bytes: "8589934592"
+    diskSetup:
+      filesystems:
+        - device: /dev/disk/azure/scsi1/lun0
+          extraOpts:
+            - -E
+            - lazy_itable_init=1,lazy_journal_init=1
+          filesystem: ext4
+          label: etcd_disk
+        - device: ephemeral0.1
+          filesystem: ext4
+          label: ephemeral0
+          replaceFS: ntfs
+      partitions:
+        - device: /dev/disk/azure/scsi1/lun0
+          layout: true
+          overwrite: false
+          tableType: gpt
+    initConfiguration:
+      nodeRegistration:
+        kubeletExtraArgs:
+          cloud-provider: external
+    joinConfiguration:
+      nodeRegistration:
+        kubeletExtraArgs:
+          cloud-provider: external
+    mounts:
+      - - LABEL=etcd_disk
+        - /var/lib/etcddisk
+    postKubeadmCommands: []
+    preKubeadmCommands: []
+  replicas: {{ .Values.controlPlane.replicas }}
+  version: {{ .Values.kubernetesVersion }}
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: AzureMachineTemplate
+metadata:
+  labels:
+    cluster.x-k8s.io/role: control-plane
+    {{- include "labels.common" $ | nindent 4 }}
+  name: {{ include "resource.default.name" $ }}-control-plane
+  namespace: {{ $.Release.Namespace }}
+spec:
+  template:
+    spec:
+      dataDisks:
+        - diskSizeGB: 256
+          lun: 0
+          nameSuffix: etcddisk
+      osDisk:
+        diskSizeGB: 128
+        osType: Linux
+      sshPublicKey: ""
+      vmSize: Standard_D2s_v3
+{{- end -}}

--- a/helm/cluster-azure/templates/_kcp.tpl
+++ b/helm/cluster-azure/templates/_kcp.tpl
@@ -135,11 +135,9 @@ spec:
       labels:
         {{- include "labels.common" $ | nindent 8 }}
     spec:
-      {{- if .Values.vmUaIdentityPrefix }}
       identity: UserAssigned
       userAssignedIdentities:
-        - providerID: {{ .Values.vmUaIdentityPrefix }}-cp
-      {{- end }}
+        - providerID: {{ include "vmUaIdentityPrefix" $ }}-cp
       dataDisks:
         - diskSizeGB: 256
           lun: 0

--- a/helm/cluster-azure/templates/_kcp.tpl
+++ b/helm/cluster-azure/templates/_kcp.tpl
@@ -128,6 +128,9 @@ metadata:
   namespace: {{ $.Release.Namespace }}
 spec:
   template:
+    metadata:
+      labels:
+        {{- include "labels.common" $ | nindent 8 }}
     spec:
       {{- if .Values.vmIdentity.type }}
       identity: {{ .Values.vmIdentity.type }}

--- a/helm/cluster-azure/templates/_kcp.tpl
+++ b/helm/cluster-azure/templates/_kcp.tpl
@@ -22,6 +22,9 @@ spec:
           - 127.0.0.1
           - localhost
         extraArgs:
+          {{- if .Values.controlPlane.serviceAccountIssuer }}
+          service-account-issuer: {{ .Values.controlPlane.serviceAccountIssuer }}
+          {{- end }}
           cloud-provider: external
           cloud-config: /etc/kubernetes/azure.json
           encryption-provider-config: /etc/kubernetes/encryption/config.yaml

--- a/helm/cluster-azure/templates/_kcp.tpl
+++ b/helm/cluster-azure/templates/_kcp.tpl
@@ -138,6 +138,9 @@ spec:
       identity: UserAssigned
       userAssignedIdentities:
         - providerID: {{ include "vmUaIdentityPrefix" $ }}-cp
+        {{- if .Values.managementCluster }}
+        - providerID: {{ include "vmUaIdentityPrefix" $ }}-capz
+        {{- end }}
       dataDisks:
         - diskSizeGB: 256
           lun: 0

--- a/helm/cluster-azure/templates/_kcp.tpl
+++ b/helm/cluster-azure/templates/_kcp.tpl
@@ -135,14 +135,10 @@ spec:
       labels:
         {{- include "labels.common" $ | nindent 8 }}
     spec:
-      {{- if .Values.vmIdentity.type }}
-      identity: {{ .Values.vmIdentity.type }}
-      {{- if gt (len .Values.vmIdentity.userAssignedIdentitiesIds) 0 }}
+      {{- if .Values.vmUaIdentityPrefix }}
+      identity: UserAssigned
       userAssignedIdentities:
-      {{- range $id := .Values.vmIdentity.userAssignedIdentitiesIds }}
-        - providerID: {{ $id }}
-      {{- end }}
-      {{- end }}
+        - providerID: {{ .Values.vmUaIdentityPrefix }}-cp
       {{- end }}
       dataDisks:
         - diskSizeGB: 256

--- a/helm/cluster-azure/templates/_kcp.tpl
+++ b/helm/cluster-azure/templates/_kcp.tpl
@@ -18,6 +18,9 @@ spec:
   kubeadmConfigSpec:
     clusterConfiguration:
       apiServer:
+        certSANs:
+          - 127.0.0.1
+          - localhost
         extraArgs:
           cloud-provider: external
           cloud-config: /etc/kubernetes/azure.json

--- a/helm/cluster-azure/templates/_kcp.tpl
+++ b/helm/cluster-azure/templates/_kcp.tpl
@@ -39,7 +39,7 @@ spec:
           bind-address: "0.0.0.0"
           logtostderr: "true"
           profiling: "false"
-          allocate-node-cidrs: "false"
+          allocate-node-cidrs: "true"
           cloud-config: /etc/kubernetes/azure.json
           cloud-provider: external
           cluster-name: {{ include "resource.default.name" $ }}

--- a/helm/cluster-azure/templates/_kcp.tpl
+++ b/helm/cluster-azure/templates/_kcp.tpl
@@ -22,15 +22,6 @@ spec:
           cloud-provider: external
           cloud-config: /etc/kubernetes/azure.json
           encryption-provider-config: /etc/kubernetes/encryption/config.yaml
-          enable-admission-plugins: NamespaceLifecycle,LimitRanger,ServiceAccount,ResourceQuota,DefaultStorageClass,PersistentVolumeClaimResize,Priority,DefaultTolerationSeconds,MutatingAdmissionWebhook,ValidatingAdmissionWebhook
-          feature-gates: TTLAfterFinished=true
-          kubelet-preferred-address-types: InternalIP
-          profiling: "false"
-          requestheader-allowed-names: "front-proxy-client"
-          runtime-config: api/all=true
-          service-account-lookup: "true"
-          tls-cipher-suites: "TLS_AES_128_GCM_SHA256,TLS_AES_256_GCM_SHA384,TLS_CHACHA20_POLY1305_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256,TLS_RSA_WITH_AES_128_CBC_SHA,TLS_RSA_WITH_AES_128_GCM_SHA256,TLS_RSA_WITH_AES_256_CBC_SHA,TLS_RSA_WITH_AES_256_GCM_SHA384"
-          service-cluster-ip-range: {{ .Values.network.serviceCIDR }}
         extraVolumes:
         - name: encryption
           hostPath: /etc/kubernetes/encryption
@@ -107,6 +98,7 @@ spec:
           cloud-config: /etc/kubernetes/azure.json
           cloud-provider: external
           feature-gates: CSIMigrationAzureDisk=true
+        name: '{{ ds.meta_data["local_hostname"] }}'
     joinConfiguration:
       nodeRegistration:
         kubeletExtraArgs:
@@ -114,6 +106,7 @@ spec:
           cloud-config: /etc/kubernetes/azure.json
           cloud-provider: external
           feature-gates: CSIMigrationAzureDisk=true
+        name: '{{ ds.meta_data["local_hostname"] }}'
     mounts:
       - - LABEL=etcd_disk
         - /var/lib/etcddisk

--- a/helm/cluster-azure/templates/_kcp.tpl
+++ b/helm/cluster-azure/templates/_kcp.tpl
@@ -98,7 +98,7 @@ spec:
           cloud-config: /etc/kubernetes/azure.json
           cloud-provider: external
           feature-gates: CSIMigrationAzureDisk=true
-        name: '{{ ds.meta_data["local_hostname"] }}'
+        name: '{{ `{{ ds.meta_data.local_hostname }}` }}'
     joinConfiguration:
       nodeRegistration:
         kubeletExtraArgs:
@@ -106,7 +106,7 @@ spec:
           cloud-config: /etc/kubernetes/azure.json
           cloud-provider: external
           feature-gates: CSIMigrationAzureDisk=true
-        name: '{{ ds.meta_data["local_hostname"] }}'
+        name: '{{ `{{ ds.meta_data.local_hostname }}` }}'
     mounts:
       - - LABEL=etcd_disk
         - /var/lib/etcddisk

--- a/helm/cluster-azure/templates/_kcp.tpl
+++ b/helm/cluster-azure/templates/_kcp.tpl
@@ -129,6 +129,15 @@ metadata:
 spec:
   template:
     spec:
+      {{- if .Values.vmIdentity.type }}
+      identity: {{ .Values.vmIdentity.type }}
+      {{- if gt (len .Values.vmIdentity.userAssignedIdentitiesIds) 0 }}
+      userAssignedIdentities:
+      {{- range $id := .Values.vmIdentity.userAssignedIdentitiesIds }}
+        - providerID: {{ $id }}
+      {{- end }}
+      {{- end }}
+      {{- end }}
       dataDisks:
         - diskSizeGB: 256
           lun: 0

--- a/helm/cluster-azure/templates/_machine_deployment.tpl
+++ b/helm/cluster-azure/templates/_machine_deployment.tpl
@@ -12,6 +12,9 @@ spec:
   selector:
     matchLabels: null
   template:
+    metadata:
+      labels:
+        {{- include "labels.common" $ | nindent 8 }}
     spec:
       bootstrap:
         configRef:
@@ -34,6 +37,9 @@ metadata:
   namespace: {{ $.Release.Namespace }}
 spec:
   template:
+    metadata:
+      labels:
+        {{- include "labels.common" $ | nindent 8 }}
     spec:
       {{- if .Values.vmIdentity.type }}
       identity: {{ .Values.vmIdentity.type }}

--- a/helm/cluster-azure/templates/_machine_deployment.tpl
+++ b/helm/cluster-azure/templates/_machine_deployment.tpl
@@ -11,6 +11,11 @@ spec:
     matchLabels: null
   template:
     spec:
+      bootstrap:
+        configRef:
+          apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+          kind: KubeadmConfigTemplate
+          name: {{ include "resource.default.name" $ }}
       clusterName: {{ include "resource.default.name" $ }}
       infrastructureRef:
         apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
@@ -31,4 +36,17 @@ spec:
         osType: Linux
       sshPublicKey: ""
       vmSize: Standard_D2s_v3
+---
+apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+kind: KubeadmConfigTemplate
+metadata:
+  name: {{ include "resource.default.name" $ }}
+  namespace: giantswarm
+spec:
+  template:
+    spec:
+      joinConfiguration:
+        nodeRegistration:
+          kubeletExtraArgs:
+            cloud-provider: external
 {{ end }}

--- a/helm/cluster-azure/templates/_machine_deployment.tpl
+++ b/helm/cluster-azure/templates/_machine_deployment.tpl
@@ -23,7 +23,7 @@ spec:
         apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
         kind: AzureMachineTemplate
         name: {{ include "resource.default.name" $ }}-md
-      version: v1.22.0
+      version: {{ .Values.kubernetesVersion }}
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: AzureMachineTemplate

--- a/helm/cluster-azure/templates/_machine_deployment.tpl
+++ b/helm/cluster-azure/templates/_machine_deployment.tpl
@@ -35,6 +35,15 @@ metadata:
 spec:
   template:
     spec:
+      {{- if .Values.vmIdentity.type }}
+      identity: {{ .Values.vmIdentity.type }}
+      {{- if gt (len .Values.vmIdentity.userAssignedIdentitiesIds) 0 }}
+      userAssignedIdentities:
+      {{- range $id := .Values.vmIdentity.userAssignedIdentitiesIds }}
+        - providerID: {{ $id }}
+      {{- end }}
+      {{- end }}
+      {{- end }}
       osDisk:
         diskSizeGB: 128
         osType: Linux

--- a/helm/cluster-azure/templates/_machine_deployment.tpl
+++ b/helm/cluster-azure/templates/_machine_deployment.tpl
@@ -60,6 +60,6 @@ spec:
             cloud-config: /etc/kubernetes/azure.json
             cloud-provider: external
             feature-gates: CSIMigrationAzureDisk=true
-          name: '{{ ds.meta_data["local_hostname"] }}'
+          name: '{{ `{{ ds.meta_data.local_hostname }}` }}'
       preKubeadmCommands: []
 {{ end }}

--- a/helm/cluster-azure/templates/_machine_deployment.tpl
+++ b/helm/cluster-azure/templates/_machine_deployment.tpl
@@ -41,14 +41,10 @@ spec:
       labels:
         {{- include "labels.common" $ | nindent 8 }}
     spec:
-      {{- if .Values.vmIdentity.type }}
-      identity: {{ .Values.vmIdentity.type }}
-      {{- if gt (len .Values.vmIdentity.userAssignedIdentitiesIds) 0 }}
+      {{- if .Values.vmUaIdentityPrefix }}
+      identity: UserAssigned
       userAssignedIdentities:
-      {{- range $id := .Values.vmIdentity.userAssignedIdentitiesIds }}
-        - providerID: {{ $id }}
-      {{- end }}
-      {{- end }}
+        - providerID: {{ .Values.vmUaIdentityPrefix }}-nodes
       {{- end }}
       osDisk:
         diskSizeGB: 128

--- a/helm/cluster-azure/templates/_machine_deployment.tpl
+++ b/helm/cluster-azure/templates/_machine_deployment.tpl
@@ -1,0 +1,34 @@
+{{- define "machine-deployment" }}
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: MachineDeployment
+metadata:
+  name: {{ include "resource.default.name" $ }}-md
+  namespace: {{ $.Release.Namespace }}
+spec:
+  clusterName: {{ include "resource.default.name" $ }}
+  replicas: 0
+  selector:
+    matchLabels: null
+  template:
+    spec:
+      clusterName: {{ include "resource.default.name" $ }}
+      infrastructureRef:
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+        kind: AzureMachineTemplate
+        name: {{ include "resource.default.name" $ }}-md
+      version: v1.22.0
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: AzureMachineTemplate
+metadata:
+  name: {{ include "resource.default.name" $ }}-md
+  namespace: {{ $.Release.Namespace }}
+spec:
+  template:
+    spec:
+      osDisk:
+        diskSizeGB: 128
+        osType: Linux
+      sshPublicKey: ""
+      vmSize: Standard_D2s_v3
+{{ end }}

--- a/helm/cluster-azure/templates/_machine_deployment.tpl
+++ b/helm/cluster-azure/templates/_machine_deployment.tpl
@@ -44,6 +44,9 @@ spec:
       identity: UserAssigned
       userAssignedIdentities:
         - providerID: {{ include "vmUaIdentityPrefix" $ }}-nodes
+        {{- if .Values.managementCluster }}
+        - providerID: {{ include "vmUaIdentityPrefix" $ }}-capz
+        {{- end }}
       osDisk:
         diskSizeGB: 128
         osType: Linux

--- a/helm/cluster-azure/templates/_machine_deployment.tpl
+++ b/helm/cluster-azure/templates/_machine_deployment.tpl
@@ -60,4 +60,6 @@ spec:
             cloud-config: /etc/kubernetes/azure.json
             cloud-provider: external
             feature-gates: CSIMigrationAzureDisk=true
+          name: '{{ ds.meta_data["local_hostname"] }}'
+      preKubeadmCommands: []
 {{ end }}

--- a/helm/cluster-azure/templates/_machine_deployment.tpl
+++ b/helm/cluster-azure/templates/_machine_deployment.tpl
@@ -15,7 +15,7 @@ spec:
         configRef:
           apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
           kind: KubeadmConfigTemplate
-          name: {{ include "resource.default.name" $ }}
+          name: {{ include "resource.default.name" $ }}-md
       clusterName: {{ include "resource.default.name" $ }}
       infrastructureRef:
         apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
@@ -40,13 +40,24 @@ spec:
 apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
 kind: KubeadmConfigTemplate
 metadata:
-  name: {{ include "resource.default.name" $ }}
-  namespace: giantswarm
+  name: {{ include "resource.default.name" $ }}-md
+  namespace: {{ $.Release.Namespace }}
 spec:
   template:
     spec:
+      files:
+        - contentFrom:
+            secret:
+              key: worker-node-azure.json
+              name: {{ include "resource.default.name" $ }}-md-0-azure-json
+          owner: root:root
+          path: /etc/kubernetes/azure.json
+          permissions: "0644"
       joinConfiguration:
         nodeRegistration:
           kubeletExtraArgs:
+            azure-container-registry-config: /etc/kubernetes/azure.json
+            cloud-config: /etc/kubernetes/azure.json
             cloud-provider: external
+            feature-gates: CSIMigrationAzureDisk=true
 {{ end }}

--- a/helm/cluster-azure/templates/_machine_deployment.tpl
+++ b/helm/cluster-azure/templates/_machine_deployment.tpl
@@ -41,11 +41,9 @@ spec:
       labels:
         {{- include "labels.common" $ | nindent 8 }}
     spec:
-      {{- if .Values.vmUaIdentityPrefix }}
       identity: UserAssigned
       userAssignedIdentities:
-        - providerID: {{ .Values.vmUaIdentityPrefix }}-nodes
-      {{- end }}
+        - providerID: {{ include "vmUaIdentityPrefix" $ }}-nodes
       osDisk:
         diskSizeGB: 128
         osType: Linux

--- a/helm/cluster-azure/templates/_machine_deployment.tpl
+++ b/helm/cluster-azure/templates/_machine_deployment.tpl
@@ -2,11 +2,13 @@
 apiVersion: cluster.x-k8s.io/v1beta1
 kind: MachineDeployment
 metadata:
+  labels:
+    {{- include "labels.common" $ | nindent 4 }}
   name: {{ include "resource.default.name" $ }}-md
   namespace: {{ $.Release.Namespace }}
 spec:
   clusterName: {{ include "resource.default.name" $ }}
-  replicas: 0
+  replicas: 3
   selector:
     matchLabels: null
   template:
@@ -26,6 +28,8 @@ spec:
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: AzureMachineTemplate
 metadata:
+  labels:
+    {{- include "labels.common" $ | nindent 4 }}
   name: {{ include "resource.default.name" $ }}-md
   namespace: {{ $.Release.Namespace }}
 spec:
@@ -40,6 +44,8 @@ spec:
 apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
 kind: KubeadmConfigTemplate
 metadata:
+  labels:
+    {{- include "labels.common" $ | nindent 4 }}
   name: {{ include "resource.default.name" $ }}-md
   namespace: {{ $.Release.Namespace }}
 spec:
@@ -49,7 +55,7 @@ spec:
         - contentFrom:
             secret:
               key: worker-node-azure.json
-              name: {{ include "resource.default.name" $ }}-md-0-azure-json
+              name: {{ include "resource.default.name" $ }}-control-plane-azure-json
           owner: root:root
           path: /etc/kubernetes/azure.json
           permissions: "0644"

--- a/helm/cluster-azure/templates/list.yaml
+++ b/helm/cluster-azure/templates/list.yaml
@@ -1,1 +1,7 @@
 {{- include "cluster" . }}
+---
+{{- include "azure-cluster" . }}
+---
+{{- include "control-plane" . }}
+---
+{{- include "machine-deployment" . }}

--- a/helm/cluster-azure/values.schema.json
+++ b/helm/cluster-azure/values.schema.json
@@ -130,9 +130,6 @@
         },
         "sshSSOPublicKey": {
             "type": "string"
-        },
-        "vmUaIdentityPrefix": {
-            "type": ["null", "string"]
         }
     }
 }

--- a/helm/cluster-azure/values.schema.json
+++ b/helm/cluster-azure/values.schema.json
@@ -7,12 +7,7 @@
             "properties": {
                 "location": {
                     "type": "string"
-                }
-            }
-        },
-        "azureCloud": {
-            "type": "object",
-            "properties": {
+                },
                 "subscriptionId": {
                     "type": "string"
                 }

--- a/helm/cluster-azure/values.schema.json
+++ b/helm/cluster-azure/values.schema.json
@@ -40,7 +40,7 @@
                     "type": "integer"
                 },
                 "serviceAccountIssuer": {
-                   "type": ["null", "string"]
+                    "type": ["null", "string"]
                 },
                 "vmSize": {
                     "type": "string"
@@ -131,17 +131,8 @@
         "sshSSOPublicKey": {
             "type": "string"
         },
-        "vmIdentity": {
-            "type": "object",
-            "properties": {
-                "type": {
-                    "type": ["null", "string"],
-                    "enum": [null, "UserAssigned", "SystemAssigned"]
-                },
-                "userAssignedIdentitiesIds": {
-                    "type": "array"
-                }
-            }
+        "vmUaIdentityPrefix": {
+            "type": ["null", "string"]
         }
     }
 }

--- a/helm/cluster-azure/values.schema.json
+++ b/helm/cluster-azure/values.schema.json
@@ -39,6 +39,9 @@
                 "rootVolumeSizeGB": {
                     "type": "integer"
                 },
+                "serviceAccountIssuer": {
+                   "type": ["null", "string"]
+                },
                 "vmSize": {
                     "type": "string"
                 }

--- a/helm/cluster-azure/values.schema.json
+++ b/helm/cluster-azure/values.schema.json
@@ -107,6 +107,9 @@
                 }
             }
         },
+        "managementCluster": {
+            "type": "boolean"
+        },
         "network": {
             "type": "object",
             "properties": {

--- a/helm/cluster-azure/values.schema.json
+++ b/helm/cluster-azure/values.schema.json
@@ -10,6 +10,14 @@
                 }
             }
         },
+        "azureCloud": {
+            "type": "object",
+            "properties": {
+                "subscriptionId": {
+                    "type": "string"
+                }
+            }
+        },
         "bastion": {
             "type": "object",
             "properties": {

--- a/helm/cluster-azure/values.schema.json
+++ b/helm/cluster-azure/values.schema.json
@@ -127,6 +127,18 @@
         },
         "sshSSOPublicKey": {
             "type": "string"
+        },
+        "vmIdentity": {
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": ["null", "string"],
+                    "enum": [null, "UserAssigned", "SystemAssigned"]
+                },
+                "userAssignedIdentitiesIds": {
+                    "type": "array"
+                }
+            }
         }
     }
 }

--- a/helm/cluster-azure/values.yaml
+++ b/helm/cluster-azure/values.yaml
@@ -42,6 +42,11 @@ machinePools:
     customNodeLabels:
       - label=default
 
+# TODO Is this the right place in the schema ? 
+vmIdentity:
+  type: null
+  userAssignedIdentitiesIds: []
+
 sshSSOPublicKey: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIM4cvZ01fLmO9cJbWUj7sfF+NhECgy+Cl0bazSrZX7sU vault-ca@vault.operations.giantswarm.io"
 
 # Used by `cluster-shared` library chart

--- a/helm/cluster-azure/values.yaml
+++ b/helm/cluster-azure/values.yaml
@@ -42,7 +42,7 @@ machinePools:
     customNodeLabels:
       - label=default
 
-# TODO Is this the right place in the schema ? 
+# TODO Is this the right place in the schema ?
 vmIdentity:
   type: null
   userAssignedIdentitiesIds: []

--- a/helm/cluster-azure/values.yaml
+++ b/helm/cluster-azure/values.yaml
@@ -48,6 +48,9 @@ azureCloud:
   # This value must be updated to the right value for the cluster to be installed
   subscriptionId: PLACEHOLDER
 
+# Is this cluster a Management Cluster or a Workload Cluster 
+managementCluster: false
+
 sshSSOPublicKey: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIM4cvZ01fLmO9cJbWUj7sfF+NhECgy+Cl0bazSrZX7sU vault-ca@vault.operations.giantswarm.io"
 
 # Used by `cluster-shared` library chart

--- a/helm/cluster-azure/values.yaml
+++ b/helm/cluster-azure/values.yaml
@@ -30,7 +30,7 @@ controlPlane:
   rootVolumeSizeGB: 120
   etcdVolumeSizeGB: 100
   # Temporary for testing, we should not really need to specify this on a per-cluster basis since it should be a predictable url
-  serviceAccountIssuer: 
+  serviceAccountIssuer:
 
 machinePools:
   # Name of node pool.

--- a/helm/cluster-azure/values.yaml
+++ b/helm/cluster-azure/values.yaml
@@ -44,6 +44,10 @@ machinePools:
     customNodeLabels:
       - label=default
 
+azureCloud:
+  # This value must be updated to the right value for the cluster to be installed
+  subscriptionId: PLACEHOLDER
+
 sshSSOPublicKey: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIM4cvZ01fLmO9cJbWUj7sfF+NhECgy+Cl0bazSrZX7sU vault-ca@vault.operations.giantswarm.io"
 
 # Used by `cluster-shared` library chart

--- a/helm/cluster-azure/values.yaml
+++ b/helm/cluster-azure/values.yaml
@@ -44,9 +44,6 @@ machinePools:
     customNodeLabels:
       - label=default
 
-# UA Identity Id Prefix for ControlPlane and worker nodes
-vmUaIdentityPrefix:
-
 sshSSOPublicKey: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIM4cvZ01fLmO9cJbWUj7sfF+NhECgy+Cl0bazSrZX7sU vault-ca@vault.operations.giantswarm.io"
 
 # Used by `cluster-shared` library chart

--- a/helm/cluster-azure/values.yaml
+++ b/helm/cluster-azure/values.yaml
@@ -29,6 +29,8 @@ controlPlane:
   replicas: 1
   rootVolumeSizeGB: 120
   etcdVolumeSizeGB: 100
+  # Temporary for testing, we should not really need to specify this on a per-cluster basis since it should be a predictable url
+  serviceAccountIssuer: 
 
 machinePools:
   # Name of node pool.

--- a/helm/cluster-azure/values.yaml
+++ b/helm/cluster-azure/values.yaml
@@ -48,7 +48,7 @@ azureCloud:
   # This value must be updated to the right value for the cluster to be installed
   subscriptionId: PLACEHOLDER
 
-# Is this cluster a Management Cluster or a Workload Cluster 
+# Is this cluster a Management Cluster or a Workload Cluster
 managementCluster: false
 
 sshSSOPublicKey: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIM4cvZ01fLmO9cJbWUj7sfF+NhECgy+Cl0bazSrZX7sU vault-ca@vault.operations.giantswarm.io"

--- a/helm/cluster-azure/values.yaml
+++ b/helm/cluster-azure/values.yaml
@@ -44,10 +44,8 @@ machinePools:
     customNodeLabels:
       - label=default
 
-# TODO Is this the right place in the schema ?
-vmIdentity:
-  type: null
-  userAssignedIdentitiesIds: []
+# UA Identity Id Prefix for ControlPlane and worker nodes
+vmUaIdentityPrefix:
 
 sshSSOPublicKey: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIM4cvZ01fLmO9cJbWUj7sfF+NhECgy+Cl0bazSrZX7sU vault-ca@vault.operations.giantswarm.io"
 

--- a/helm/cluster-azure/values.yaml
+++ b/helm/cluster-azure/values.yaml
@@ -9,6 +9,8 @@ releaseVersion: 20.0.0-alpha1
 
 azure:
   location: "westeurope"
+  # This value must be updated to the right value for the cluster to be installed
+  subscriptionId: PLACEHOLDER
 
 network:
   bastionSubnet: "10.2.0.0/16"
@@ -44,9 +46,6 @@ machinePools:
     customNodeLabels:
       - label=default
 
-azureCloud:
-  # This value must be updated to the right value for the cluster to be installed
-  subscriptionId: PLACEHOLDER
 
 # Is this cluster a Management Cluster or a Workload Cluster
 managementCluster: false


### PR DESCRIPTION
- initial capz based cluster crs
- add kubeadmconfigtemplate
- fix
- strip down api config
- fix hostname
- allocate-node-cidrs
- set serviceCIDR
- add label selector
- set md replica size
- add additional cert sans
- Add identity fields to spec
- Remove whitespace
- Add common labels to all objects
- Remove watch-filter label since we are not filtering on it anymore in capz
- Allow setting custom `service-account-issuer` to test AZWI
- Remove empty trailing space
- Convert VM UserAssigned Identity value to a Prefix string
