### PR TITLE
fix wrong indention in kubeadmconfig

### DIFF
--- a/helm/cluster-azure/templates/_machine_pool.tpl
+++ b/helm/cluster-azure/templates/_machine_pool.tpl
@@ -74,14 +74,14 @@ metadata:
   namespace: {{ $.Release.Namespace }}
 spec:
   joinConfiguration: {{ include "machinepool-kubeadmconfig-spec" $ | nindent 4 }}
-    files:
-    - contentFrom:
-        secret:
-          key: worker-node-azure.json
-          name: {{ include "resource.default.name" $ }}-{{ .name }}-{{ include "hash" (dict "data" (include "machinepool-kubeadmconfig-spec" $) .) }}-azure-json
-      owner: root:root
-      path: /etc/kubernetes/azure.json
-      permissions: "0644"
+  files:
+  - contentFrom:
+      secret:
+        key: worker-node-azure.json
+        name: {{ include "resource.default.name" $ }}-{{ .name }}-{{ include "hash" (dict "data" (include "machinepool-azuremachinepool-spec" $data) .) }}-azure-json
+    owner: root:root
+    path: /etc/kubernetes/azure.json
+    permissions: "0644"
 ---
 {{- end }}
 {{- end -}}


### PR DESCRIPTION
files section was moved one layer to deep and therefore the required files doesn't appear on the worker nodes