### PR TITLE
Add `cluster.x-k8s.io/watch-filter: capi` to common labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Added
 
 - Initial support to create a workload cluster via CAPI/CAPZ.
+- Add `cluster.x-k8s.io/watch-filter: capi` to common labels.
 
 ## [0.0.1] - 2022-11-22
 

--- a/helm/cluster-azure/templates/_helpers.tpl
+++ b/helm/cluster-azure/templates/_helpers.tpl
@@ -26,6 +26,7 @@ giantswarm.io/cluster: {{ include "resource.default.name" . | quote }}
 giantswarm.io/organization: {{ .Values.organization | quote }}
 helm.sh/chart: {{ include "chart" . | quote }}
 application.giantswarm.io/team: {{ index .Chart.Annotations "application.giantswarm.io/team" | quote }}
+cluster.x-k8s.io/watch-filter: capi
 {{- end -}}
 
 {{/*


### PR DESCRIPTION
This change adds `cluster.x-k8s.io/watch-filter: capi` to common labels so that CAPZ controllers can use `watch-filter` argument and filter and reconcile CRs with this label.

CAPI/CAPZ MCs do not need this option, but we are also running same CAPI and CAPZ controllers on vintage MCs where this is required.