### PR TITLE
Enable PodSecurityPolicy admission plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Enable PodSecurityPolicy admission plugin when version is `lt` 1.25.0
 - Default to 3 replicas for control plane
 - add giantswam user to the KCP and Machinepool configuration
 - Add support for custom taints and labels on machinepools

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Enable PodSecurityPolicy admission plugin when version is `lt` 1.25.0
+- Add helm chart dependency for `cluster-shared` , required by the PSP admission controller
 - Default to 3 replicas for control plane
 - add giantswam user to the KCP and Machinepool configuration
 - Add support for custom taints and labels on machinepools

--- a/helm/cluster-azure/Chart.lock
+++ b/helm/cluster-azure/Chart.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: cluster-shared
+  repository: https://giantswarm.github.io/cluster-catalog
+  version: 0.6.4
+digest: sha256:8df8c11fb4553caa08324abbbd9d119422049e26de209c747c6a0f91b1343783
+generated: "2023-01-18T12:34:24.259129629+01:00"

--- a/helm/cluster-azure/Chart.yaml
+++ b/helm/cluster-azure/Chart.yaml
@@ -13,4 +13,3 @@ dependencies:
 - name: cluster-shared
   version: "0.6.4"
   repository: "https://giantswarm.github.io/cluster-catalog"
-

--- a/helm/cluster-azure/Chart.yaml
+++ b/helm/cluster-azure/Chart.yaml
@@ -8,3 +8,9 @@ annotations:
 restrictions:
   compatibleProviders:
     - azure
+    - capz
+dependencies:
+- name: cluster-shared
+  version: "0.6.4"
+  repository: "https://giantswarm.github.io/cluster-catalog"
+

--- a/helm/cluster-azure/ci/ci-values.yaml
+++ b/helm/cluster-azure/ci/ci-values.yaml
@@ -1,0 +1,2 @@
+organization: "test"
+baseDomain: example.com

--- a/helm/cluster-azure/templates/_helpers.tpl
+++ b/helm/cluster-azure/templates/_helpers.tpl
@@ -98,6 +98,8 @@ List of admission plugins to enable based on apiVersion
 - name: giantswarm
   groups: sudo
   sudo: ALL=(ALL) NOPASSWD:ALL
+  sshAuthorizedKeys:
+    - {{ .Values.sshSSOPublicKey }}
 {{- end -}}
 
 {{- define "oidcFiles" -}}

--- a/helm/cluster-azure/templates/_helpers.tpl
+++ b/helm/cluster-azure/templates/_helpers.tpl
@@ -47,6 +47,8 @@ List of admission plugins to enable based on apiVersion
 {{- $enabledPlugins := list "" -}}
 {{- if semverCompare "<1.25.0" .Capabilities.KubeVersion.Version -}}
 {{- $enabledPlugins = append $enabledPlugins "PodSecurityPolicy" -}}
+{{- end -}}
+{{- if not (empty (compact $enabledPlugins)) -}}
 ,{{- join "," (compact $enabledPlugins) }}
 {{- end -}}
 {{- end -}}

--- a/helm/cluster-azure/templates/_helpers.tpl
+++ b/helm/cluster-azure/templates/_helpers.tpl
@@ -30,6 +30,17 @@ cluster.x-k8s.io/watch-filter: capi
 {{- end -}}
 
 {{/*
+Selector labels
+*/}}
+{{- define "labels.selector" -}}
+app: {{ include "name" . | quote }}
+app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+cluster.x-k8s.io/cluster-name: {{ include "resource.default.name" . | quote }}
+giantswarm.io/cluster: {{ include "resource.default.name" . | quote }}
+giantswarm.io/organization: {{ required "You must provide an existing organization" .Values.organization | quote }}
+{{- end -}}
+
+{{/*
 Create a name stem for resource names
 When resources are created from templates by Cluster API controllers, they are given random suffixes.
 Given that Kubernetes allows 63 characters for resource names, the stem is truncated to 47 characters to leave

--- a/helm/cluster-azure/templates/_helpers.tpl
+++ b/helm/cluster-azure/templates/_helpers.tpl
@@ -39,6 +39,18 @@ room for such suffix.
 {{- .Values.clusterName | default (.Release.Name | replace "." "-" | trunc 47 | trimSuffix "-") -}}
 {{- end -}}
 
+
+{{/*
+List of admission plugins to enable based on apiVersion
+*/}}
+{{- define "enabled-admission-plugins" -}}
+{{- $enabledPlugins := list "" -}}
+{{- if semverCompare "<1.25.0" .Capabilities.KubeVersion.Version -}}
+{{- $enabledPlugins = append $enabledPlugins "PodSecurityPolicy" -}}
+,{{- join "," (compact $enabledPlugins) }}
+{{- end -}}
+{{- end -}}
+
 {{/*Helper to define per cluster User Assigned Identity prefix*/}}
 {{- define "vmUaIdentityPrefix" -}}
 /subscriptions/{{ .Values.azure.subscriptionId }}/resourceGroups/{{ include "resource.default.name" . }}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{{ include "resource.default.name" . }}

--- a/helm/cluster-azure/templates/_helpers.tpl
+++ b/helm/cluster-azure/templates/_helpers.tpl
@@ -18,15 +18,10 @@ Create chart name and version as used by the chart label.
 Common labels
 */}}
 {{- define "labels.common" -}}
-app: {{ include "name" . | quote }}
-app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+{{- include "labels.selector" $ }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
-cluster.x-k8s.io/cluster-name: {{ include "resource.default.name" . | quote }}
-giantswarm.io/cluster: {{ include "resource.default.name" . | quote }}
-giantswarm.io/organization: {{ .Values.organization | quote }}
 helm.sh/chart: {{ include "chart" . | quote }}
 application.giantswarm.io/team: {{ index .Chart.Annotations "application.giantswarm.io/team" | quote }}
-cluster.x-k8s.io/watch-filter: capi
 {{- end -}}
 
 {{/*

--- a/helm/cluster-azure/templates/_helpers.tpl
+++ b/helm/cluster-azure/templates/_helpers.tpl
@@ -104,8 +104,6 @@ List of admission plugins to enable based on apiVersion
 - name: giantswarm
   groups: sudo
   sudo: ALL=(ALL) NOPASSWD:ALL
-  sshAuthorizedKeys:
-    - {{ .Values.sshSSOPublicKey }}
 {{- end -}}
 
 {{- define "oidcFiles" -}}

--- a/helm/cluster-azure/templates/_kcp.tpl
+++ b/helm/cluster-azure/templates/_kcp.tpl
@@ -141,7 +141,6 @@ spec:
           tableType: gpt
     files:
     {{- include "oidcFiles" . | nindent 4 }}
-    {{- include "sshFiles" . | nindent 4 }}
     {{- include "kubeletReservationFiles" $ | nindent 4 }}
     - contentFrom:
         secret:

--- a/helm/cluster-azure/templates/_kcp.tpl
+++ b/helm/cluster-azure/templates/_kcp.tpl
@@ -141,6 +141,7 @@ spec:
           tableType: gpt
     files:
     {{- include "oidcFiles" . | nindent 4 }}
+    {{- include "sshFiles" . | nindent 4 }}
     {{- include "kubeletReservationFiles" $ | nindent 4 }}
     - contentFrom:
         secret:

--- a/helm/cluster-azure/templates/_kcp.tpl
+++ b/helm/cluster-azure/templates/_kcp.tpl
@@ -64,7 +64,7 @@ spec:
           audit-log-path: /var/log/apiserver/audit.log
           audit-policy-file: /etc/kubernetes/policies/audit-policy.yaml
           encryption-provider-config: /etc/kubernetes/encryption/config.yaml
-          enable-admission-plugins: NamespaceLifecycle,LimitRanger,ServiceAccount,ResourceQuota,DefaultStorageClass,PersistentVolumeClaimResize,Priority,DefaultTolerationSeconds,MutatingAdmissionWebhook,ValidatingAdmissionWebhook
+          enable-admission-plugins: NamespaceLifecycle,LimitRanger,ServiceAccount,ResourceQuota,DefaultStorageClass,PersistentVolumeClaimResize,Priority,DefaultTolerationSeconds,MutatingAdmissionWebhook,ValidatingAdmissionWebhook{{- include "enabled-admission-plugins" $ }}
           feature-gates: TTLAfterFinished=true
           kubelet-preferred-address-types: InternalIP
           profiling: "false"

--- a/helm/cluster-azure/templates/list.yaml
+++ b/helm/cluster-azure/templates/list.yaml
@@ -1,3 +1,8 @@
+{{- if semverCompare "<1.25.0" .Capabilities.KubeVersion.Version -}}
+---
+{{- include "psps" . }}
+{{- end }}
+---
 {{- include "cluster" . }}
 ---
 {{- include "azure-cluster" . }}

--- a/helm/cluster-azure/values.yaml
+++ b/helm/cluster-azure/values.yaml
@@ -54,6 +54,9 @@ enablePerClusterIdentity: false
 
 sshSSOPublicKey: "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDnfhWCBrplizz7XzX1Sc+I57TvCe+EEARTeYBuqWa3BRNVysSdPdbxHHJ6qzVY66snO4wq4yokno0yBdA7hAV73Y38/yZEzdKux+UyRwrnoerOdOw/590U6Pkm1mB9YhUQ4XrS5j67ZNUc/LeSQ+aWf65HATcLUccfIIVNt7OOEl+VGvg9Pvoukg+A/mSoYdBQssGNbzB+8niK5ohIsKMxS0aqaLlEZMtXxZuD8YDvIRO2m8n+djQ6wqi4HTVcBKRREa5blVu3Ug42O4XDvcdHxqHyPCUSU7ho/PJDR1B45gub+hKt/O4EdtzVZE4Z7hGQEfXUd5C0mbg+V5gcxLtt"
 
+# Used by `cluster-shared` library chart
+includeClusterResourceSet: true
+
 oidc:
   issuerUrl: ""
   caPem: ""


### PR DESCRIPTION
Enable the PSP Admission plugin

* Requires the `cluster-shared` helm chart dependency to install the actual PSP resources 
* Only enable the PSP resources and the plugin on kubernetes <1.25 ( xref: [documentation](https://kubernetes.io/blog/2022/08/23/kubernetes-v1-25-release/#pod-security-changes) ) 
* add `values.yaml` for ci to set a fake `organization` which now fails the rendering if not define ( copied from capa ) 