### PR TITLE
Restore of MachineDeployments support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Add support for MachineDeployments
+- Add MachineDeployments to Values.yaml
+
+### Changed
+
+- Move common templates between MachineDeployments and MachinePools into an helper file ( \_machine_helpers.tpl )
+
 ## [0.0.3] - 2023-01-19
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Add support for MachineDeployments
 - Add MachineDeployments to Values.yaml
+- Add MachineHealthChecks for Worker Nodes in MachineDeployments. Enabled by default
 
 ### Changed
 

--- a/helm/cluster-azure/templates/_machine_deployments.tpl
+++ b/helm/cluster-azure/templates/_machine_deployments.tpl
@@ -62,5 +62,36 @@ spec:
   template:
     spec: {{- include "machine-kubeadmconfig-spec" (merge $data $azureMachineTemplateHash ) | nindent 6 }}
 ---
+{{- if not .disableHealthChecks }}
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: MachineHealthCheck
+metadata:
+  annotations:
+    machine-deployment.giantswarm.io/name: {{ include "resource.default.name" $ }}-{{ .name }}
+  labels:
+    giantswarm.io/machine-deployment: {{ include "resource.default.name" $ }}-{{ .name }}
+    {{- include "labels.common" $ | nindent 4 }}
+  name: {{ include "resource.default.name" $ }}-{{ .name }}
+  namespace: {{ $.Release.Namespace }}
+spec:
+  clusterName: {{ include "resource.default.name" $ }}
+  # (Optional) maxUnhealthy prevents further remediation if the cluster is already partially unhealthy
+  maxUnhealthy: 40%
+  # (Optional) nodeStartupTimeout determines how long a MachineHealthCheck should wait for
+  # a Node to join the cluster, before considering a Machine unhealthy.
+  nodeStartupTimeout: 10m
+  # selector is used to determine which Machines should be health checked
+  selector:
+    matchLabels:
+      "cluster.x-k8s.io/deployment-name": {{ include "resource.default.name" $ }}-{{ .name }}
+  # Conditions to check on Nodes for matched Machines, if any condition is matched for the duration of its timeout, the Machine is considered unhealthy
+  unhealthyConditions:
+  - type: Ready
+    status: Unknown
+    timeout: 300s
+  - type: Ready
+    status: "False"
+    timeout: 300s
+{{- end }}
 {{- end }}
 {{- end -}}

--- a/helm/cluster-azure/templates/_machine_deployments.tpl
+++ b/helm/cluster-azure/templates/_machine_deployments.tpl
@@ -55,9 +55,6 @@ spec:
 apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
 kind: KubeadmConfigTemplate
 metadata:
-{{- /* Do we need this annotation when hashing is enabled to avoid deleting the Secret when the name change ? Do we even need to hash this ? */}}
-{{- /*  annotations: */}}
-{{- /*    "helm.sh/resource-policy": keep */}}
   labels:
     giantswarm.io/machine-deployment: {{ include "resource.default.name" $ }}-{{ .name }}
     {{- include "labels.common" $ | nindent 4 }}

--- a/helm/cluster-azure/templates/_machine_deployments.tpl
+++ b/helm/cluster-azure/templates/_machine_deployments.tpl
@@ -1,0 +1,71 @@
+{{- define "machine-deployments" -}}
+{{- range $machineDeployment := .Values.machineDeployments }}
+{{ $data := dict "spec" $machineDeployment "type" "machineDeployment" "Values" $.Values "Release" $.Release "Files" $.Files "Template" $.Template }}
+{{ $kubeAdmConfigTemplateHash := dict "hash" ( include "hash" (dict "data" (include "machine-kubeadmconfig-spec" $data) "global" $) ) }}
+{{ $azureMachineTemplateHash := dict "hash" ( include "hash" (dict "data" ( dict "spec" (include "machine-spec" $data) "identity" (include "machine-identity" $data) ) "global" $) ) }}
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: MachineDeployment
+metadata:
+  annotations:
+    machine-deployment.giantswarm.io/name: {{ include "resource.default.name" $ }}-{{ .name }}
+  labels:
+    giantswarm.io/machine-deployment: {{ include "resource.default.name" $ }}-{{ .name }}
+    {{- include "labels.common" $ | nindent 4 }}
+  name: {{ include "resource.default.name" $ }}-{{ .name }}
+  namespace: {{ $.Release.Namespace }}
+spec:
+  clusterName: {{ include "resource.default.name" $ }}
+  replicas: {{ .replicas }}
+  selector:
+    matchLabels: null
+  template:
+    metadata:
+      labels:
+        {{- include "labels.common" $ | nindent 8 }}
+    spec:
+      bootstrap:
+        configRef:
+          apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+          kind: KubeadmConfigTemplate
+          name: {{ include "resource.default.name" $ }}-{{ .name }}-{{ $kubeAdmConfigTemplateHash.hash }}
+      clusterName: {{ include "resource.default.name" $ }}
+      infrastructureRef:
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+        kind: AzureMachineTemplate
+        name: {{ include "resource.default.name" $ }}-{{ .name }}-{{ $azureMachineTemplateHash.hash }}
+      version: {{ $.Values.kubernetesVersion }}
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: AzureMachineTemplate
+metadata:
+  labels:
+    giantswarm.io/machine-deployment: {{ include "resource.default.name" $ }}-{{ .name }}
+    {{- include "labels.common" $ | nindent 4 }}
+  name: {{ include "resource.default.name" $ }}-{{ .name }}-{{ $azureMachineTemplateHash.hash }}
+  namespace: {{ $.Release.Namespace }}
+spec:
+  template:
+    metadata:
+      labels:
+        {{- include "labels.common" $ | nindent 8 }}
+    spec:
+      {{- include "machine-identity" $data | nindent 6}}
+      {{- include "machine-spec" $data | nindent 6}}
+---
+apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+kind: KubeadmConfigTemplate
+metadata:
+{{- /* Do we need this annotation when hashing is enabled to avoid deleting the Secret when the name change ? Do we even need to hash this ? */}}
+{{- /*  annotations: */}}
+{{- /*    "helm.sh/resource-policy": keep */}}
+  labels:
+    giantswarm.io/machine-deployment: {{ include "resource.default.name" $ }}-{{ .name }}
+    {{- include "labels.common" $ | nindent 4 }}
+  name: {{ include "resource.default.name" $ }}-{{ .name }}-{{ $kubeAdmConfigTemplateHash.hash }}
+  namespace: {{ $.Release.Namespace }}
+spec:
+  template:
+    spec: {{- include "machine-kubeadmconfig-spec" (merge $data $azureMachineTemplateHash ) | nindent 6 }}
+---
+{{- end }}
+{{- end -}}

--- a/helm/cluster-azure/templates/_machine_deployments.tpl
+++ b/helm/cluster-azure/templates/_machine_deployments.tpl
@@ -16,8 +16,6 @@ metadata:
 spec:
   clusterName: {{ include "resource.default.name" $ }}
   replicas: {{ .replicas }}
-  selector:
-    matchLabels: null
   template:
     metadata:
       labels:

--- a/helm/cluster-azure/templates/_machine_helpers.tpl
+++ b/helm/cluster-azure/templates/_machine_helpers.tpl
@@ -1,0 +1,59 @@
+{{/*
+Helpers to reuse when defining specs for MachinePools and MachineDeployments
+*/}}
+
+{{- define "machine-identity" -}}
+{{- if .Values.enablePerClusterIdentity -}}
+identity: UserAssigned
+userAssignedIdentities:
+  - providerID: {{ include "vmUaIdentityPrefix" $ }}-cp
+  {{- if .Values.attachCapzControllerIdentity }}
+  - providerID: {{ include "vmUaIdentityPrefix" $ }}-capz
+  {{- end }}
+{{ end -}}
+{{- end -}}
+
+{{- define "machine-spec" -}}
+osDisk:
+  diskSizeGB: {{ .spec.rootVolumeSizeGB }}
+  managedDisk:
+    storageAccountType: Premium_LRS
+  osType: Linux
+sshPublicKey: {{ $.Values.sshSSOPublicKey | b64enc }}
+vmSize: {{ .spec.instanceType }}
+{{- end -}}
+
+{{- define "machine-kubeadmconfig-spec" -}}
+joinConfiguration:
+  nodeRegistration:
+    kubeletExtraArgs:
+      azure-container-registry-config: /etc/kubernetes/azure.json
+      cloud-config: /etc/kubernetes/azure.json
+      cloud-provider: external
+      feature-gates: CSIMigrationAzureDisk=true
+      eviction-soft: {{ .spec.softEvictionThresholds | default .Values.defaults.softEvictionThresholds }}
+      eviction-soft-grace-period: {{ .spec.softEvictionGracePeriod | default .Values.defaults.softEvictionGracePeriod }}
+      eviction-hard: {{ .spec.hardEvictionThresholds | default .Values.defaults.hardEvictionThresholds }}
+      eviction-minimum-reclaim: {{ .Values.controlPlane.evictionMinimumReclaim | default .Values.defaults.evictionMinimumReclaim }}
+      node-labels: role=worker,giantswarm.io/machine-{{ternary "pool" "deployment" (eq .type "machinePool")}}={{ include "resource.default.name" $ }}-{{ .spec.name }}{{- if (and (hasKey .spec "customNodeLabels") (gt (len .spec.customNodeLabels) 0) ) }},{{- join "," .spec.customNodeLabels }}{{- end }}
+    name: '{{ `{{ ds.meta_data.local_hostname }}` }}'
+    {{- if .spec.customNodeTaints }}
+    taints:
+    {{- include "customNodeTaints" .spec.customNodeTaints | indent 6 }}
+    {{- end }}
+files:
+  - contentFrom:
+      secret:
+        key: worker-node-azure.json
+        name: {{ include "resource.default.name" $ }}-{{ .spec.name }}{{ ternary (printf "-%s" .hash) "" (hasKey . "hash") }}-azure-json
+    owner: root:root
+    path: /etc/kubernetes/azure.json
+    permissions: "0644"
+{{- include "kubeletReservationFiles" $ | nindent 2 }}
+{{- include "sshFiles" $ | nindent 2 }}
+preKubeadmCommands:
+{{- include "kubeletReservationPreCommands" . | nindent 2 }}
+postKubeadmCommands: []
+users:
+{{- include "sshUsers" . | nindent 2 }}
+{{- end }}

--- a/helm/cluster-azure/templates/_machine_pool.tpl
+++ b/helm/cluster-azure/templates/_machine_pool.tpl
@@ -1,64 +1,6 @@
-{{- define "machinepool-azuremachinepool-spec" -}}
-{{- if .Values.enablePerClusterIdentity -}}
-identity: UserAssigned
-userAssignedIdentities:
-  - providerID: {{ include "vmUaIdentityPrefix" $ }}-nodes
-  {{- if .Values.attachCapzControllerIdentity }}
-  - providerID: {{ include "vmUaIdentityPrefix" $ }}-capz
-  {{- end }}
-{{ end -}}
-location: {{ .machinePool.location }}
-strategy:
-  rollingUpdate:
-    deletePolicy: Oldest
-    maxSurge: 25%
-    maxUnavailable: 1
-  type: RollingUpdate
-template:
-  osDisk:
-    diskSizeGB: {{ .machinePool.rootVolumeSizeGB }}
-    managedDisk:
-      storageAccountType: Premium_LRS
-    osType: Linux
-  sshPublicKey: {{ .Values.sshSSOPublicKey | b64enc }}
-  vmSize: {{ .machinePool.instanceType }}
-{{- end -}}
-
-{{- define "machinepool-kubeadmconfig-spec" -}}
-joinConfiguration:
-  nodeRegistration:
-    kubeletExtraArgs:
-      cloud-config: /etc/kubernetes/azure.json
-      cloud-provider: external
-      eviction-soft: {{ .machinePool.softEvictionThresholds | default .Values.defaults.softEvictionThresholds }}
-      eviction-soft-grace-period: {{ .machinePool.softEvictionGracePeriod | default .Values.defaults.softEvictionGracePeriod }}
-      eviction-hard: {{ .machinePool.hardEvictionThresholds | default .Values.defaults.hardEvictionThresholds }}
-      eviction-minimum-reclaim: {{ .Values.controlPlane.evictionMinimumReclaim | default .Values.defaults.evictionMinimumReclaim }}
-      node-labels: role=worker,giantswarm.io/machine-pool={{ include "resource.default.name" $ }}-{{ .machinePool.name }}{{- if (gt (len .machinePool.customNodeLabels) 0) }},{{- join "," .machinePool.customNodeLabels }}{{- end }}
-    name: '{{ `{{ ds.meta_data.local_hostname }}` }}'
-    {{- if .machinePool.customNodeTaints }}
-    taints:
-    {{- include "customNodeTaints" .machinePool.customNodeTaints | indent 6 }}
-    {{- end }}
-files:
-  - contentFrom:
-      secret:
-        key: worker-node-azure.json
-        name: {{ include "resource.default.name" $ }}-{{ .machinePool.name }}-azure-json
-    owner: root:root
-    path: /etc/kubernetes/azure.json
-    permissions: "0644"
-{{- include "kubeletReservationFiles" $ | nindent 2 }}
-preKubeadmCommands:
-{{- include "kubeletReservationPreCommands" . | nindent 2 }}
-postKubeadmCommands: []
-users:
-{{- include "sshUsers" . | nindent 2 }}
-{{- end }}
-
 {{- define "machine-pools" -}}
 {{- range $machinePool := .Values.machinePools }}
-{{ $data := dict "machinePool" $machinePool "Values" $.Values "Release" $.Release "Files" $.Files }}
+{{ $data := dict "spec" $machinePool "type" "machinePool" "Values" $.Values "Release" $.Release "Files" $.Files "Template" $.Template }}
 apiVersion: cluster.x-k8s.io/v1beta1
 kind: MachinePool
 metadata:
@@ -94,21 +36,27 @@ metadata:
     {{- include "labels.common" $ | nindent 4 }}
   name: {{ include "resource.default.name" $ }}-{{ .name }}
   namespace: {{ $.Release.Namespace }}
-spec: {{- include "machinepool-azuremachinepool-spec" $data | nindent 2}}
+spec:
+  {{- include "machine-identity" $data | nindent 2}}
+  location: {{ $data.spec.location }}
+  strategy:
+    rollingUpdate:
+      deletePolicy: Oldest
+      maxSurge: 25%
+      maxUnavailable: 1
+    type: RollingUpdate
+  template: {{- include "machine-spec" $data | nindent 4}}
+
 ---
 apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
 kind: KubeadmConfig
 metadata:
-{{- if $.Values.enableMachinePoolHashing }}
-  annotations:
-    "helm.sh/resource-policy": keep
-{{- end }}
   labels:
     giantswarm.io/machine-pool: {{ include "resource.default.name" $ }}-{{ .name }}
     {{- include "labels.common" $ | nindent 4 }}
   name: {{ include "resource.default.name" $ }}-{{ .name }}
   namespace: {{ $.Release.Namespace }}
-spec: {{- include "machinepool-kubeadmconfig-spec" $data | nindent 2 }}
+spec: {{- include "machine-kubeadmconfig-spec" $data | nindent 2 }}
 ---
 {{- end }}
 {{- end -}}

--- a/helm/cluster-azure/templates/list.yaml
+++ b/helm/cluster-azure/templates/list.yaml
@@ -10,3 +10,5 @@
 {{- include "control-plane" . }}
 ---
 {{- include "machine-pools" . }}
+---
+{{- include "machine-deployments" . }}

--- a/helm/cluster-azure/values.yaml
+++ b/helm/cluster-azure/values.yaml
@@ -50,6 +50,7 @@ machineDeployments:
     instanceType: Standard_D2s_v3
     replicas: 3
     rootVolumeSizeGB: 50
+    disableHealthCheck: false
     customNodeLabels: []
     customNodeTaints: []
     # - key: ""

--- a/helm/cluster-azure/values.yaml
+++ b/helm/cluster-azure/values.yaml
@@ -32,12 +32,23 @@ defaults:
   hardEvictionThresholds: memory.available<200Mi,nodefs.available<10%,nodefs.inodesFree<3%,imagefs.available<10%,pid.available<20%
   evictionMinimumReclaim: imagefs.available=5%,memory.available=100Mi,nodefs.available=5%
 
-machinePools:
-  - name: def00
-    location: "westeurope"
+machinePools: []
+#  - name: def00
+#    location: "westeurope"
+#    instanceType: Standard_D2s_v3
+#    minSize: 3
+#    maxSize: 3
+#    rootVolumeSizeGB: 50
+#    customNodeLabels: []
+#    customNodeTaints: []
+#    # - key: ""
+#    #   value: ""
+#    #   effect: "" # Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+
+machineDeployments:
+  - name: md00
     instanceType: Standard_D2s_v3
-    minSize: 3
-    maxSize: 3
+    replicas: 3
     rootVolumeSizeGB: 50
     customNodeLabels: []
     customNodeTaints: []


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/1897

- Add support for MachineDeployments ( requires deletion-blocker-operator running on cluster ) 
- Make MachineDeployments the default and disable MachinePools 
- Move common templates between MD and MP to a common helpers file 

TODO
 * I will update the schema in a separate PR to work with the changes from Marian
 * Create FollowUP Issue about 
   * [x] when rolling CP nodes it will briefly cause some other nodes to go into `NotReady` state , does this depend on the LB still having the node as a backend ? it should not affect kubelet though which should use the `kubernetes` service  - https://github.com/giantswarm/roadmap/issues/1934
   * [x] Remove `chart version` label from machines, or everytime we update  chart we get a full restart even when is not required - https://github.com/giantswarm/roadmap/issues/1935
   
Tested
* Upgrade Kubernetes Version
  * Worked great respecting Surge settings and rolling all nodes 
    * In our templates we only have a single value for this so all Deployments and CP nodes are upgraded at once
* Change _something_ in MD kubeadmconfigtemplate 
  * Worked great thanks to the `deletion-blocker-operator`
* Change _instnace size_ for MD
  * Worked great thanks to the `deletion-blocker-operator`