### PR TITLE
Example of using jsonnet to help generating schema file

### DIFF
--- a/Makefile.schema.mk
+++ b/Makefile.schema.mk
@@ -1,0 +1,8 @@
+HELM_DIR:=helm/cluster-azure
+
+generate-schema:
+	cd $(HELM_DIR) && \
+	helm schema-gen values.yaml > values.schema-generated.json && \
+	jsonnet -e "(import 'values.schema-generated.json') + (import 'values.schema-static.libsonnet')" > values.schema.json && \
+	schemalint normalize values.schema.json -o values.schema.json --force && \
+	schemalint verify values.schema.json

--- a/helm/cluster-azure/values.schema-generated.json
+++ b/helm/cluster-azure/values.schema-generated.json
@@ -1,0 +1,152 @@
+{
+    "$schema": "http://json-schema.org/schema#",
+    "type": "object",
+    "properties": {
+        "attachCapzControllerIdentity": {
+            "type": "boolean"
+        },
+        "azure": {
+            "type": "object",
+            "properties": {
+                "azureClusterIdentity": {
+                    "type": "object",
+                    "properties": {
+                        "name": {
+                            "type": "string"
+                        },
+                        "namespace": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "location": {
+                    "type": "string"
+                },
+                "subscriptionId": {
+                    "type": "string"
+                }
+            }
+        },
+        "clusterDescription": {
+            "type": "string"
+        },
+        "clusterName": {
+            "type": "string"
+        },
+        "controlPlane": {
+            "type": "object",
+            "properties": {
+                "etcdVolumeSizeGB": {
+                    "type": "integer"
+                },
+                "instanceType": {
+                    "type": "string"
+                },
+                "replicas": {
+                    "type": "integer"
+                },
+                "rootVolumeSizeGB": {
+                    "type": "integer"
+                }
+            }
+        },
+        "defaults": {
+            "type": "object",
+            "properties": {
+                "evictionMinimumReclaim": {
+                    "type": "string"
+                },
+                "hardEvictionThresholds": {
+                    "type": "string"
+                },
+                "softEvictionGracePeriod": {
+                    "type": "string"
+                },
+                "softEvictionThresholds": {
+                    "type": "string"
+                }
+            }
+        },
+        "enablePerClusterIdentity": {
+            "type": "boolean"
+        },
+        "includeClusterResourceSet": {
+            "type": "boolean"
+        },
+        "kubernetesVersion": {
+            "type": "string"
+        },
+        "machineDeployments": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "customNodeLabels": {
+                        "type": "array"
+                    },
+                    "customNodeTaints": {
+                        "type": "array"
+                    },
+                    "disableHealthCheck": {
+                        "type": "boolean"
+                    },
+                    "instanceType": {
+                        "type": "string"
+                    },
+                    "name": {
+                        "type": "string"
+                    },
+                    "replicas": {
+                        "type": "integer"
+                    },
+                    "rootVolumeSizeGB": {
+                        "type": "integer"
+                    }
+                }
+            }
+        },
+        "machinePools": {
+            "type": "array"
+        },
+        "network": {
+            "type": "object",
+            "properties": {
+                "hostCIDR": {
+                    "type": "string"
+                },
+                "podCIDR": {
+                    "type": "string"
+                },
+                "serviceCIDR": {
+                    "type": "string"
+                }
+            }
+        },
+        "oidc": {
+            "type": "object",
+            "properties": {
+                "caPem": {
+                    "type": "string"
+                },
+                "clientId": {
+                    "type": "string"
+                },
+                "groupsClaim": {
+                    "type": "string"
+                },
+                "issuerUrl": {
+                    "type": "string"
+                },
+                "usernameClaim": {
+                    "type": "string"
+                }
+            }
+        },
+        "organization": {
+            "type": "string"
+        },
+        "sshSSOPublicKey": {
+            "type": "string"
+        }
+    }
+}

--- a/helm/cluster-azure/values.schema-static.libsonnet
+++ b/helm/cluster-azure/values.schema-static.libsonnet
@@ -1,0 +1,187 @@
+{
+  description: 'Configuration of an Azure cluster using Cluster API',
+  properties+: {
+    attachCapzControllerIdentity+: {
+      title: 'Attach controller identity',
+    },
+    azure+: {
+      properties+: {
+        azureClusterIdentity+: {
+          description: 'AzureClusterIdentity resource to use for this cluster.',
+          properties+: {
+            name+: {
+              title: 'Name',
+            },
+            namespace+: {
+              title: 'Namespace',
+            },
+          },
+          title: 'Identity',
+        },
+        location+: {
+          title: 'Location',
+        },
+        subscriptionId+: {
+          title: 'Subscription ID',
+        },
+      },
+      title: 'Azure settings',
+    },
+    clusterDescription+: {
+      description: "User-friendly description of the cluster's purpose.",
+      title: 'Cluster description',
+    },
+    clusterName+: {
+      description: 'Unique identifier, cannot be changed after creation.',
+      title: 'Cluster name',
+    },
+    controlPlane+: {
+      properties+: {
+        etcdVolumeSizeGB+: {
+          title: 'Etcd volume size (GB)',
+        },
+        instanceType+: {
+          title: 'Node VM size',
+        },
+        replicas+: {
+          title: 'Number of nodes',
+        },
+        rootVolumeSizeGB+: {
+          title: 'Root volume size (GB)',
+        },
+      },
+      title: 'Control plane settings',
+    },
+    defaults+: {
+      properties+: {
+        evictionMinimumReclaim+: {
+          title: 'Default settings for eviction minimum reclaim',
+        },
+        hardEvictionThresholds+: {
+          title: 'Default settings for hard eviction thresholds',
+        },
+        softEvictionGracePeriod+: {
+          title: 'Default settings for soft eviction grace period',
+        },
+        softEvictionThresholds+: {
+          title: 'Default settings for soft eviction thresholds',
+        },
+      },
+    },
+    enablePerClusterIdentity+: {
+      title: 'Enable identity per cluster',
+    },
+    includeClusterResourceSet+: {
+    },
+    kubernetesVersion+: {
+      title: 'Kubernetes version',
+    },
+    machineDeployments+: {
+      items+: {
+        properties+: {
+          customNodeLabels+: {
+            items+: {
+              title: 'Label',
+              type: 'string',
+            },
+            title: 'Custom node labels',
+          },
+          customNodeTaints+: {
+            descriptions: 'Taints that will be set on all nodes in the node pool, to avoid the scheduling of certain workloads.',
+            items+: {
+              properties+: {
+                effect+: {
+                  enum: [
+                    'NoSchedule',
+                    'PreferNoSchedule',
+                    'NoExecute',
+                  ],
+                  title: 'Effect',
+                  type: 'string',
+                },
+                key+: {
+                  title: 'Key',
+                  type: 'string',
+                },
+                value+: {
+                  title: 'Value',
+                  type: 'string',
+                },
+              },
+              required+: [
+                'effect',
+                'key',
+                'value',
+              ],
+              type: 'object',
+              title: 'Node taint',
+            },
+            title: 'Custom node taints',
+          },
+          disableHealthCheck+: {
+            title: 'Disable HealthChecks for the MachineDeployment',
+          },
+          instanceType+: {
+            title: 'VM size',
+          },
+          name+: {
+            description: 'Unique identifier, cannot be changed after creation.',
+            title: 'Name',
+          },
+          replicas+: {
+            title: 'Number of nodes in the MachineDeployment',
+          },
+          rootVolumeSizeGB+: {
+            title: 'Root volume size (GB)',
+          },
+        },
+        title: 'Node pool',
+      },
+      title: 'Node pools',
+    },
+    machinePools+: {
+    },
+    network+: {
+      properties+: {
+        hostCIDR+: {
+          title: 'Host CIDR',
+        },
+        podCIDR+: {
+          title: 'Pod CIDR',
+        },
+        serviceCIDR+: {
+          title: 'Service CIDR',
+        },
+      },
+      title: 'Network settings',
+    },
+    oidc+: {
+      properties+: {
+        caPem+: {
+          description: "Identity provider's CA certificate in PEM format.",
+          title: 'Certificate authority',
+        },
+        clientId+: {
+          title: 'Client ID',
+        },
+        groupsClaim+: {
+          title: 'Groups claim',
+        },
+        issuerUrl+: {
+          title: 'Issuer URL',
+        },
+        usernameClaim+: {
+          title: 'Username claim',
+        },
+      },
+      title: 'OIDC settings',
+    },
+    organization+: {
+      title: 'Organization',
+    },
+    sshSSOPublicKey+: {
+      title: 'SSH Public key for SSO',
+    },
+  },
+  title: 'Cluster configuration',
+}


### PR DESCRIPTION
This is not to be merged, just an example for @marians 

#### Requirements:
* jsonnet binary - https://github.com/google/jsonnet
* schemalint
* helm schema-gen plugin

#### How it works

* all static , manual , values are moved to `values.schema-static.libsonnet` 
  * this file _extends_ known objects by using `jsonnet` `+:` override syntax https://jsonnet.org/learning/tutorial.html
* the generated schema from values is moved to `values.schema-generated.json` 
* a simple Makefile is added
* run `make generate-schema` 

essentially
* the manual overrides of the schema are all moved to a separate file ( values.schema-static.jsonnet ) 
  * title
  * description
  * enums
  * ...
* the generated ones from helm are generated into a separate file ( values.schema-generated.json ) jsonnet then merge the generated with the static one using the jsonnet override feature `+:` into the final `values.schema.json`

this way the static values are never lost when the generated ones is updated due to changes in the values

also we could have validation done in the jsonnet static file to identify
* fields that dot not have a title
* whatever