### PR TITLE
Run schemalint as GitHub action

### DIFF
--- a/.github/workflows/schemalint.yaml
+++ b/.github/workflows/schemalint.yaml
@@ -4,7 +4,7 @@ on:
 
 jobs:
   validate:
-    name: Validate values.schema.json with schemalint
+    name: Validate values.schema.json
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout code

--- a/.github/workflows/schemalint.yaml
+++ b/.github/workflows/schemalint.yaml
@@ -1,4 +1,4 @@
-name: Schemalint
+name: schemalint
 on:
   pull_request: {}
 

--- a/.github/workflows/schemalint.yaml
+++ b/.github/workflows/schemalint.yaml
@@ -19,4 +19,4 @@ jobs:
           go install github.com/giantswarm/schemalint@latest
       - name: Run schemalint
         run: |
-          schemalint verify ./helm/cluster-azure/values.schema.json
+          schemalint verify ./helm/cluster-azure/values.schema.json --rule-set cluster-app

--- a/.github/workflows/schemalint.yaml
+++ b/.github/workflows/schemalint.yaml
@@ -1,0 +1,22 @@
+name: Schemalint
+on:
+  pull_request: {}
+
+jobs:
+  validate:
+    name: Validate values.schema.json with schemalint
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - uses: actions/setup-go@v3
+        with:
+          go-version: "^1.19"
+
+      - name: Install schemalint
+        run: |
+          go install go install github.com/giantswarm/schemalint@latest
+      - name: Run schemalint
+        run: |
+          schemalint verify ./helm/cluster-azure/values.schema.json

--- a/.github/workflows/schemalint.yaml
+++ b/.github/workflows/schemalint.yaml
@@ -16,7 +16,7 @@ jobs:
 
       - name: Install schemalint
         run: |
-          go install go install github.com/giantswarm/schemalint@latest
+          go install github.com/giantswarm/schemalint@latest
       - name: Run schemalint
         run: |
           schemalint verify ./helm/cluster-azure/values.schema.json

--- a/helm/cluster-azure/values.schema.json
+++ b/helm/cluster-azure/values.schema.json
@@ -177,6 +177,78 @@
         "machinePools": {
             "$comment": "/machineDeployments is used instead.",
             "deprecated": true,
+            "items": {
+                "properties": {
+                    "customNodeLabels": {
+                        "items": {
+                            "title": "Label",
+                            "type": "string"
+                        },
+                        "title": "Custom node labels",
+                        "type": "array"
+                    },
+                    "customNodeTaints": {
+                        "descriptions": "Taints that will be set on all nodes in the node pool, to avoid the scheduling of certain workloads.",
+                        "items": {
+                            "properties": {
+                                "effect": {
+                                    "enum": [
+                                        "NoSchedule",
+                                        "PreferNoSchedule",
+                                        "NoExecute"
+                                    ],
+                                    "title": "Effect",
+                                    "type": "string"
+                                },
+                                "key": {
+                                    "title": "Key",
+                                    "type": "string"
+                                },
+                                "value": {
+                                    "title": "Value",
+                                    "type": "string"
+                                }
+                            },
+                            "required": [
+                                "effect",
+                                "key",
+                                "value"
+                            ],
+                            "title": "Node taint",
+                            "type": "object"
+                        },
+                        "title": "Custom node taints",
+                        "type": "array"
+                    },
+                    "instanceType": {
+                        "title": "VM size",
+                        "type": "string"
+                    },
+                    "location": {
+                        "title": "Location",
+                        "type": "string"
+                    },
+                    "maxSize": {
+                        "title": "Maximum number of nodes",
+                        "type": "integer"
+                    },
+                    "minSize": {
+                        "title": "Minimum number of nodes",
+                        "type": "integer"
+                    },
+                    "name": {
+                        "description": "Unique identifier, cannot be changed after creation.",
+                        "title": "Name",
+                        "type": "string"
+                    },
+                    "rootVolumeSizeGB": {
+                        "title": "Root volume size (GB)",
+                        "type": "integer"
+                    }
+                },
+                "title": "Node pool",
+                "type": "object"
+            },
             "title": "Machine pools (deprecated)",
             "type": "array"
         },


### PR DESCRIPTION
This PR adds a GitHub action, which will run `schemalint verify` on the `values.schema.json` file.

Schemalint will verify that the JSON schema
- is valid
- is normalized (consistent indentation and sorting)
- fulfills the [requirements we have on cluster-app schemas](https://github.com/giantswarm/rfc/pull/55)

This is the first time that the validation of the cluster-app schemas is used in production. If you have any problems reach out to Team Rainbow.
Also if you want to discuss the rules implemented, feel free to contribute to the RFC mentioned above.  