### PR TITLE
Set JSON schema draft, add annotations

### DIFF
--- a/helm/cluster-azure/values.schema.json
+++ b/helm/cluster-azure/values.schema.json
@@ -86,6 +86,7 @@
                     "type": "string"
                 }
             },
+            "title": "Default settings",
             "type": "object"
         },
         "enablePerClusterIdentity": {
@@ -93,6 +94,8 @@
             "type": "boolean"
         },
         "includeClusterResourceSet": {
+            "description": "If true, a ClusterResourceSet resource is generated for the cluster.",
+            "title": "Include ClusterResourceSet",
             "type": "boolean"
         },
         "kubernetesVersion": {
@@ -172,6 +175,9 @@
             "type": "array"
         },
         "machinePools": {
+            "$comment": "/machineDeployments is used instead.",
+            "deprecated": true,
+            "title": "Machine pools (deprecated)",
             "type": "array"
         },
         "network": {

--- a/helm/cluster-azure/values.schema.json
+++ b/helm/cluster-azure/values.schema.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "http://json-schema.org/schema#",
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
     "description": "Configuration of an Azure cluster using Cluster API",
     "properties": {
         "attachCapzControllerIdentity": {


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/1733

The goal is to make the schema valid with regard to our [requirements for cluster-apps](https://github.com/giantswarm/rfc/pull/55).

This PR does

- Sets the draft to `https://json-schema.org/draft/2019-09/schema`, which is the one we require for cluster apps
- add mandatory and a few optional annotation fields
- Adds `deprecated` to the `/machinePools` property, together with an (internal) `$comment`