### PR TITLE
Pre Create /var/lib/kubelet

### DIFF
--- a/helm/cluster-azure/templates/_helpers.tpl
+++ b/helm/cluster-azure/templates/_helpers.tpl
@@ -129,7 +129,7 @@ List of admission plugins to enable based on apiVersion
 
 {{- define "varLibKubeletDir" -}}
 - /bin/mkdir -p /var/lib/kubelet
-- /bin/chmod 0755 /var/lib/kubelet
+- /bin/chmod 0750 /var/lib/kubelet
 {{- end -}}
 
 {{/*

--- a/helm/cluster-azure/templates/_helpers.tpl
+++ b/helm/cluster-azure/templates/_helpers.tpl
@@ -127,9 +127,8 @@ List of admission plugins to enable based on apiVersion
 - /opt/bin/calculate_kubelet_reservations.sh
 {{- end -}}
 
-{{- define "varLibKubeletDir" -}}
-- /bin/mkdir -p /var/lib/kubelet
-- /bin/chmod 0750 /var/lib/kubelet
+{{- define "prepare-varLibKubelet-Dir" -}}
+- /bin/test ! -d /var/lib/kubelet && (/bin/mkdir -p /var/lib/kubelet && /bin/chmod 0750 /var/lib/kubelet)
 {{- end -}}
 
 {{/*

--- a/helm/cluster-azure/templates/_helpers.tpl
+++ b/helm/cluster-azure/templates/_helpers.tpl
@@ -127,6 +127,11 @@ List of admission plugins to enable based on apiVersion
 - /opt/bin/calculate_kubelet_reservations.sh
 {{- end -}}
 
+{{- define "varLibKubeletDir" -}}
+- /bin/mkdir -p /var/lib/kubelet
+- /bin/chmod 0755 /var/lib/kubelet
+{{- end -}}
+
 {{/*
 Hash function based on data provided
 Expects two arguments (as a `dict`) E.g.

--- a/helm/cluster-azure/templates/_kcp.tpl
+++ b/helm/cluster-azure/templates/_kcp.tpl
@@ -198,6 +198,7 @@ spec:
       - - LABEL=etcd_disk
         - /var/lib/etcddisk
     preKubeadmCommands:
+    {{- include "varLibKubeletDir" . | nindent 6 }}
     {{- include "kubeletReservationPreCommands" . | nindent 6 }}
     postKubeadmCommands: []
     users:

--- a/helm/cluster-azure/templates/_kcp.tpl
+++ b/helm/cluster-azure/templates/_kcp.tpl
@@ -198,7 +198,7 @@ spec:
       - - LABEL=etcd_disk
         - /var/lib/etcddisk
     preKubeadmCommands:
-    {{- include "varLibKubeletDir" . | nindent 6 }}
+    {{- include "prepare-varLibKubelet-Dir" . | nindent 6 }}
     {{- include "kubeletReservationPreCommands" . | nindent 6 }}
     postKubeadmCommands: []
     users:

--- a/helm/cluster-azure/templates/_machine_helpers.tpl
+++ b/helm/cluster-azure/templates/_machine_helpers.tpl
@@ -52,7 +52,7 @@ files:
 {{- include "kubeletReservationFiles" $ | nindent 2 }}
 {{- include "sshFiles" $ | nindent 2 }}
 preKubeadmCommands:
-{{- include "varLibKubeletDir" . | nindent 2 }}
+{{- include "prepare-varLibKubelet-Dir" . | nindent 2 }}
 {{- include "kubeletReservationPreCommands" . | nindent 2 }}
 postKubeadmCommands: []
 users:

--- a/helm/cluster-azure/templates/_machine_helpers.tpl
+++ b/helm/cluster-azure/templates/_machine_helpers.tpl
@@ -52,6 +52,7 @@ files:
 {{- include "kubeletReservationFiles" $ | nindent 2 }}
 {{- include "sshFiles" $ | nindent 2 }}
 preKubeadmCommands:
+{{- include "varLibKubeletDir" . | nindent 2 }}
 {{- include "kubeletReservationPreCommands" . | nindent 2 }}
 postKubeadmCommands: []
 users:


### PR DESCRIPTION
This might not be the best solution to address https://github.com/giantswarm/giantswarm/issues/25275 

* restore the same permissions for `/var/lib/kubelet` as it was up to CAPI images `1.24.9` and `1.23.15` 
