### PR TITLE
Schema structure: rename /azure to /provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Moved /clusterName to /metadata/name
   - Moved /clusterDescription to /metadata/description
   - Moved /organization to /metadata/organization
+  - Renamed /azure to /provider
 
 ## [0.0.4] - 2023-02-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,16 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.0.5] - 2023-02-08
-
 ### Changed
+
+- **Breaking change** to values schema - make sure to update your values before updating to this releaseValues schema:
+  - Renamed /azure to /provider
+
+## [0.0.5] - 2023-02-08
 
 **Breaking Change** - make sure to update your values before updating to this release
 - Values schema:
   - Moved /clusterName to /metadata/name
   - Moved /clusterDescription to /metadata/description
   - Moved /organization to /metadata/organization
-  - Renamed /azure to /provider
 
 ## [0.0.4] - 2023-02-01
 

--- a/helm/cluster-azure/templates/_azure_cluster.tpl
+++ b/helm/cluster-azure/templates/_azure_cluster.tpl
@@ -10,9 +10,9 @@ spec:
   identityRef:
     apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
     kind: AzureClusterIdentity
-    name: {{ .Values.azure.azureClusterIdentity.name }}
-    namespace: {{ .Values.azure.azureClusterIdentity.namespace }}
-  location: {{ .Values.azure.location }}
+    name: {{ .Values.provider.azureClusterIdentity.name }}
+    namespace: {{ .Values.provider.azureClusterIdentity.namespace }}
+  location: {{ .Values.provider.location }}
   networkSpec:
     subnets:
       - name: control-plane-subnet
@@ -26,5 +26,5 @@ spec:
       cidrBlocks:
       - {{ .Values.network.hostCIDR }}
   resourceGroup: {{ include "resource.default.name" $ }}
-  subscriptionID: {{ .Values.azure.subscriptionId }}
+  subscriptionID: {{ .Values.provider.subscriptionId }}
 {{ end }}

--- a/helm/cluster-azure/templates/_helpers.tpl
+++ b/helm/cluster-azure/templates/_helpers.tpl
@@ -61,7 +61,7 @@ List of admission plugins to enable based on apiVersion
 
 {{/*Helper to define per cluster User Assigned Identity prefix*/}}
 {{- define "vmUaIdentityPrefix" -}}
-/subscriptions/{{ .Values.azure.subscriptionId }}/resourceGroups/{{ include "resource.default.name" . }}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{{ include "resource.default.name" . }}
+/subscriptions/{{ .Values.provider.subscriptionId }}/resourceGroups/{{ include "resource.default.name" . }}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{{ include "resource.default.name" . }}
 {{- end -}}
 
 {{/*Render list of custom Taints from passed values*/}}

--- a/helm/cluster-azure/values.schema.json
+++ b/helm/cluster-azure/values.schema.json
@@ -6,35 +6,6 @@
             "title": "Attach controller identity",
             "type": "boolean"
         },
-        "azure": {
-            "properties": {
-                "azureClusterIdentity": {
-                    "description": "AzureClusterIdentity resource to use for this cluster.",
-                    "properties": {
-                        "name": {
-                            "title": "Name",
-                            "type": "string"
-                        },
-                        "namespace": {
-                            "title": "Namespace",
-                            "type": "string"
-                        }
-                    },
-                    "title": "Identity",
-                    "type": "object"
-                },
-                "location": {
-                    "title": "Location",
-                    "type": "string"
-                },
-                "subscriptionId": {
-                    "title": "Subscription ID",
-                    "type": "string"
-                }
-            },
-            "title": "Azure settings",
-            "type": "object"
-        },
         "controlPlane": {
             "properties": {
                 "etcdVolumeSizeGB": {
@@ -305,6 +276,35 @@
                 }
             },
             "title": "OIDC settings",
+            "type": "object"
+        },
+        "provider": {
+            "properties": {
+                "azureClusterIdentity": {
+                    "description": "AzureClusterIdentity resource to use for this cluster.",
+                    "properties": {
+                        "name": {
+                            "title": "Name",
+                            "type": "string"
+                        },
+                        "namespace": {
+                            "title": "Namespace",
+                            "type": "string"
+                        }
+                    },
+                    "title": "Identity",
+                    "type": "object"
+                },
+                "location": {
+                    "title": "Location",
+                    "type": "string"
+                },
+                "subscriptionId": {
+                    "title": "Subscription ID",
+                    "type": "string"
+                }
+            },
+            "title": "Azure settings",
             "type": "object"
         },
         "sshSSOPublicKey": {

--- a/helm/cluster-azure/values.yaml
+++ b/helm/cluster-azure/values.yaml
@@ -10,7 +10,7 @@ metadata:
 
 kubernetesVersion: 1.24.8
 
-azure:
+provider:
   location: "westeurope"
   # This value must be updated to the right value for the cluster to be installed
   subscriptionId: PLACEHOLDER


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/1990

This PR renames the `/azure` section to `/provider` (which is the intended name for all providers).