### PR TITLE
Remove /clusterDescription and /clusterName

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Removed
+
+- Values schema: removed redundant and unused /clusterName and /clusterDescription properties.
+
 ## [0.0.6] - 2023-02-08
 
 ### Added
+
 - Add support for Bastion host as a MachineDeployment
 
 ## [0.0.5] - 2023-02-08
@@ -17,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 **Breaking Change** - make sure to update your values before updating to this release
+
 - Values schema:
   - Moved /clusterName to /metadata/name
   - Moved /clusterDescription to /metadata/description
@@ -25,6 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.0.4] - 2023-02-01
 
 ### Added
+
 - Add support for MachineDeployments
 - Add MachineDeployments to Values.yaml
 - Add MachineHealthChecks for Worker Nodes in MachineDeployments. Enabled by default

--- a/helm/cluster-azure/values.schema.json
+++ b/helm/cluster-azure/values.schema.json
@@ -49,16 +49,6 @@
             "title": "Bastion settings",
             "type": "object"
         },
-        "clusterDescription": {
-            "description": "User-friendly description of the cluster's purpose.",
-            "title": "Cluster description",
-            "type": "string"
-        },
-        "clusterName": {
-            "description": "Unique identifier, cannot be changed after creation.",
-            "title": "Cluster name",
-            "type": "string"
-        },
         "controlPlane": {
             "properties": {
                 "etcdVolumeSizeGB": {


### PR DESCRIPTION
This PR removes redundant properties that got re-introduced in https://github.com/giantswarm/cluster-azure/pull/39