### PR TITLE
Values schema: rename /provider to /providerSpecific

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - **Breaking change** to values schema - make sure to update your values before updating to this releaseValues schema:
-  - Renamed /azure to /provider
+  - Renamed /azure to /providerSpecific
 
 ### Removed
 

--- a/helm/cluster-azure/templates/_azure_cluster.tpl
+++ b/helm/cluster-azure/templates/_azure_cluster.tpl
@@ -10,9 +10,9 @@ spec:
   identityRef:
     apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
     kind: AzureClusterIdentity
-    name: {{ .Values.provider.azureClusterIdentity.name }}
-    namespace: {{ .Values.provider.azureClusterIdentity.namespace }}
-  location: {{ .Values.provider.location }}
+    name: {{ .Values.providerSpecific.azureClusterIdentity.name }}
+    namespace: {{ .Values.providerSpecific.azureClusterIdentity.namespace }}
+  location: {{ .Values.providerSpecific.location }}
   networkSpec:
     subnets:
       - name: control-plane-subnet
@@ -26,5 +26,5 @@ spec:
       cidrBlocks:
       - {{ .Values.network.hostCIDR }}
   resourceGroup: {{ include "resource.default.name" $ }}
-  subscriptionID: {{ .Values.provider.subscriptionId }}
+  subscriptionID: {{ .Values.providerSpecific.subscriptionId }}
 {{ end }}

--- a/helm/cluster-azure/templates/_helpers.tpl
+++ b/helm/cluster-azure/templates/_helpers.tpl
@@ -61,7 +61,7 @@ List of admission plugins to enable based on apiVersion
 
 {{/*Helper to define per cluster User Assigned Identity prefix*/}}
 {{- define "vmUaIdentityPrefix" -}}
-/subscriptions/{{ .Values.provider.subscriptionId }}/resourceGroups/{{ include "resource.default.name" . }}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{{ include "resource.default.name" . }}
+/subscriptions/{{ .Values.providerSpecific.subscriptionId }}/resourceGroups/{{ include "resource.default.name" . }}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{{ include "resource.default.name" . }}
 {{- end -}}
 
 {{/*Render list of custom Taints from passed values*/}}

--- a/helm/cluster-azure/values.schema.json
+++ b/helm/cluster-azure/values.schema.json
@@ -300,7 +300,7 @@
             "title": "OIDC settings",
             "type": "object"
         },
-        "provider": {
+        "providerSpecific": {
             "properties": {
                 "azureClusterIdentity": {
                     "description": "AzureClusterIdentity resource to use for this cluster.",

--- a/helm/cluster-azure/values.yaml
+++ b/helm/cluster-azure/values.yaml
@@ -10,7 +10,7 @@ metadata:
 
 kubernetesVersion: 1.24.8
 
-provider:
+providerSpecific:
   location: "westeurope"
   # This value must be updated to the right value for the cluster to be installed
   subscriptionId: PLACEHOLDER


### PR DESCRIPTION
We found a name conflict with /provider, so we are switching to /providerSpecific in values schema.