### PR TITLE
Move /network to /connectivity/network

### DIFF
--- a/helm/cluster-azure/templates/_azure_cluster.tpl
+++ b/helm/cluster-azure/templates/_azure_cluster.tpl
@@ -24,7 +24,7 @@ spec:
     vnet:
       name: {{ include "resource.default.name" $ }}-vnet
       cidrBlocks:
-      - {{ .Values.network.hostCIDR }}
+      - {{ .Values.connectivity.network.hostCidr }}
   resourceGroup: {{ include "resource.default.name" $ }}
   subscriptionID: {{ .Values.providerSpecific.subscriptionId }}
 {{ end }}

--- a/helm/cluster-azure/templates/_bastion.tpl
+++ b/helm/cluster-azure/templates/_bastion.tpl
@@ -13,8 +13,8 @@ osDisk:
     storageAccountType: Premium_LRS
   osType: Linux
 sshPublicKey: {{ include "fake-rsa-ssh-key" $ | b64enc }}
-subnetName: {{ $.spec.subnetName | default (ternary "node-subnet" "control-plane-subnet" (eq .Values.network.mode "private" )) }}
-allocatePublicIP: {{ ternary false true (eq .Values.network.mode "private" ) }}
+subnetName: {{ $.spec.subnetName | default (ternary "node-subnet" "control-plane-subnet" (eq .Values.connectivity.network.mode "private" )) }}
+allocatePublicIP: {{ ternary false true (eq .Values.connectivity.network.mode "private" ) }}
 vmSize: {{ .spec.instanceType }}
 {{- end -}}
 

--- a/helm/cluster-azure/templates/_cluster.tpl
+++ b/helm/cluster-azure/templates/_cluster.tpl
@@ -13,10 +13,10 @@ spec:
   clusterNetwork:
     services:
       cidrBlocks:
-       - {{ .Values.network.serviceCIDR }}
+       - {{ .Values.connectivity.network.serviceCidr }}
     pods:
       cidrBlocks:
-      - {{ .Values.network.podCIDR }}
+      - {{ .Values.connectivity.network.podCidr }}
   controlPlaneRef:
     apiVersion: controlplane.cluster.x-k8s.io/v1beta1
     kind: KubeadmControlPlane

--- a/helm/cluster-azure/templates/_kcp.tpl
+++ b/helm/cluster-azure/templates/_kcp.tpl
@@ -71,7 +71,7 @@ spec:
           runtime-config: api/all=true,scheduling.k8s.io/v1alpha1=true
           service-account-lookup: "true"
           tls-cipher-suites: TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_RSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_128_GCM_SHA256
-          service-cluster-ip-range: {{ .Values.network.serviceCIDR }}
+          service-cluster-ip-range: {{ .Values.connectivity.network.serviceCidr }}
         extraVolumes:
         - name: auditlog
           hostPath: /var/log/apiserver
@@ -121,7 +121,7 @@ spec:
             listen-metrics-urls: "http://0.0.0.0:2381"
             quota-backend-bytes: "8589934592"
       networking:
-        serviceSubnet: {{ .Values.network.serviceCIDR }}
+        serviceSubnet: {{ .Values.connectivity.network.serviceCidr }}
     diskSetup:
       filesystems:
         - device: /dev/disk/azure/scsi1/lun0

--- a/helm/cluster-azure/values.schema.json
+++ b/helm/cluster-azure/values.schema.json
@@ -25,8 +25,8 @@
                 "network": {
                     "properties": {
                         "hostCidr": {
-                            "title": "Node subnet",
                             "description": "IPv4 address range for nodes, in CIDR notation.",
+                            "title": "Node subnet",
                             "type": "string"
                         },
                         "mode": {
@@ -38,13 +38,13 @@
                             "type": "string"
                         },
                         "podCidr": {
-                            "title": "Pod subnet",
                             "description": "IPv4 address range for pods, in CIDR notation.",
+                            "title": "Pod subnet",
                             "type": "string"
                         },
                         "serviceCidr": {
-                            "title": "Service subnet",
                             "description": "IPv4 address range for services, in CIDR notation.",
+                            "title": "Service subnet",
                             "type": "string"
                         }
                     },

--- a/helm/cluster-azure/values.schema.json
+++ b/helm/cluster-azure/values.schema.json
@@ -21,6 +21,35 @@
                     },
                     "title": "Bastion settings",
                     "type": "object"
+                },
+                "network": {
+                    "properties": {
+                        "hostCidr": {
+                            "title": "Node subnet",
+                            "description": "IPv4 address range for nodes, in CIDR notation.",
+                            "type": "string"
+                        },
+                        "mode": {
+                            "enum": [
+                                "public",
+                                "private"
+                            ],
+                            "title": "Network mode",
+                            "type": "string"
+                        },
+                        "podCidr": {
+                            "title": "Pod subnet",
+                            "description": "IPv4 address range for pods, in CIDR notation.",
+                            "type": "string"
+                        },
+                        "serviceCidr": {
+                            "title": "Service subnet",
+                            "description": "IPv4 address range for services, in CIDR notation.",
+                            "type": "string"
+                        }
+                    },
+                    "title": "Network settings",
+                    "type": "object"
                 }
             },
             "title": "Connectivity settings",
@@ -278,32 +307,6 @@
                 }
             },
             "title": "Metadata",
-            "type": "object"
-        },
-        "network": {
-            "properties": {
-                "hostCIDR": {
-                    "title": "Host CIDR",
-                    "type": "string"
-                },
-                "mode": {
-                    "enum": [
-                        "public",
-                        "private"
-                    ],
-                    "title": "Network mode",
-                    "type": "string"
-                },
-                "podCIDR": {
-                    "title": "Pod CIDR",
-                    "type": "string"
-                },
-                "serviceCIDR": {
-                    "title": "Service CIDR",
-                    "type": "string"
-                }
-            },
-            "title": "Network settings",
             "type": "object"
         },
         "providerSpecific": {

--- a/helm/cluster-azure/values.yaml
+++ b/helm/cluster-azure/values.yaml
@@ -18,16 +18,15 @@ providerSpecific:
     name: "cluster-identity"
     namespace: "org-giantswarm"
 
-network:
-  serviceCIDR: 172.31.0.0/16
-  podCIDR: "192.168.0.0/16"
-  hostCIDR: "10.0.0.0/8"
-  mode: public
-
 connectivity:
   bastion:
     enabled: true
     instanceType: Standard_D2s_v5
+  network:
+    serviceCidr: "172.31.0.0/16"
+    podCidr: "192.168.0.0/16"
+    hostCidr: "10.0.0.0/8"
+    mode: public
 
 controlPlane:
   instanceType: Standard_D4s_v3


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/1990

This PR

- moves all `/network` values into `/connectivity`
- adapts the property name spelling to camelCase (e. g. `serviceCIDR` to `serviceCidr`)
- improves annotations (title and description)