### PR TITLE
Add service priority cluster label

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add option to specify the `giantswarm.io/service-priority` cluster label.
+
 ### Changed
 
 - **Breaking change** to values schema - make sure to update your values before updating to this releaseValues schema:

--- a/helm/cluster-azure/ci/ci-values.yaml
+++ b/helm/cluster-azure/ci/ci-values.yaml
@@ -1,3 +1,4 @@
 metadata:
-  organization: "test"
+  organization: test
+  servicePriority: lowest
 baseDomain: example.com

--- a/helm/cluster-azure/templates/_cluster.tpl
+++ b/helm/cluster-azure/templates/_cluster.tpl
@@ -6,6 +6,9 @@ metadata:
     cluster.giantswarm.io/description: "{{ .Values.metadata.description }}"
   labels:
     cluster-apps-operator.giantswarm.io/watching: ""
+    {{- if .Values.metadata.servicePriority }}
+    giantswarm.io/service-priority: {{ .Values.metadata.servicePriority }}
+    {{- end }}
     {{- include "labels.common" $ | nindent 4 }}
   name: {{ include "resource.default.name" $ }}
   namespace: {{ .Release.Namespace }}

--- a/helm/cluster-azure/values.schema.json
+++ b/helm/cluster-azure/values.schema.json
@@ -320,6 +320,18 @@
                 "organization": {
                     "title": "Organization",
                     "type": "string"
+                },
+                "servicePriority": {
+                    "$comment": "Defined in https://github.com/giantswarm/rfc/tree/main/classify-cluster-priority",
+                    "default": "highest",
+                    "description": "The relative importance of this cluster.",
+                    "enum": [
+                        "highest",
+                        "medium",
+                        "lowest"
+                    ],
+                    "title": "Service priority",
+                    "type": "string"
                 }
             },
             "title": "Metadata",


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/13342

This PR adds the option to specify the `giantswarm.io/service-priority` label via the app values.