### PR TITLE
Remove support for customizing eviction settings on a per node basis

### DIFF
--- a/helm/cluster-azure/templates/_kcp.tpl
+++ b/helm/cluster-azure/templates/_kcp.tpl
@@ -169,10 +169,10 @@ spec:
           cloud-config: /etc/kubernetes/azure.json
           cloud-provider: external
           feature-gates: CSIMigrationAzureDisk=true
-          eviction-soft: {{ .Values.controlPlane.softEvictionThresholds | default .Values.internal.defaults.softEvictionThresholds }}
-          eviction-soft-grace-period: {{ .Values.controlPlane.softEvictionGracePeriod | default .Values.internal.defaults.softEvictionGracePeriod }}
-          eviction-hard: {{ .Values.controlPlane.hardEvictionThresholds | default .Values.internal.defaults.hardEvictionThresholds }}
-          eviction-minimum-reclaim: {{ .Values.controlPlane.evictionMinimumReclaim | default .Values.internal.defaults.evictionMinimumReclaim }}
+          eviction-soft: {{ .Values.internal.defaults.softEvictionThresholds }}
+          eviction-soft-grace-period: {{ .Values.internal.defaults.softEvictionGracePeriod }}
+          eviction-hard: {{ .Values.internal.defaults.hardEvictionThresholds }}
+          eviction-minimum-reclaim: {{ .Values.internal.defaults.evictionMinimumReclaim }}
         name: '{{ `{{ ds.meta_data.local_hostname }}` }}'
         {{- if .Values.controlPlane.customNodeTaints }}
         taints:
@@ -185,10 +185,10 @@ spec:
           cloud-config: /etc/kubernetes/azure.json
           cloud-provider: external
           feature-gates: CSIMigrationAzureDisk=true
-          eviction-soft: {{ .Values.controlPlane.softEvictionThresholds | default .Values.internal.defaults.softEvictionThresholds }}
-          eviction-soft-grace-period: {{ .Values.controlPlane.softEvictionGracePeriod | default .Values.internal.defaults.softEvictionGracePeriod }}
-          eviction-hard: {{ .Values.controlPlane.hardEvictionThresholds | default .Values.internal.defaults.hardEvictionThresholds }}
-          eviction-minimum-reclaim: {{ .Values.controlPlane.evictionMinimumReclaim | default .Values.internal.defaults.evictionMinimumReclaim }}
+          eviction-soft: {{ .Values.internal.defaults.softEvictionThresholds }}
+          eviction-soft-grace-period: {{ .Values.internal.defaults.softEvictionGracePeriod }}
+          eviction-hard: {{ .Values.internal.defaults.hardEvictionThresholds }}
+          eviction-minimum-reclaim: {{ .Values.internal.defaults.evictionMinimumReclaim }}
         name: '{{ `{{ ds.meta_data.local_hostname }}` }}'
         {{- if .Values.controlPlane.customNodeTaints }}
         taints:

--- a/helm/cluster-azure/templates/_machine_helpers.tpl
+++ b/helm/cluster-azure/templates/_machine_helpers.tpl
@@ -31,10 +31,10 @@ joinConfiguration:
       cloud-config: /etc/kubernetes/azure.json
       cloud-provider: external
       feature-gates: CSIMigrationAzureDisk=true
-      eviction-soft: {{ .spec.softEvictionThresholds | default .Values.internal.defaults.softEvictionThresholds }}
-      eviction-soft-grace-period: {{ .spec.softEvictionGracePeriod | default .Values.internal.defaults.softEvictionGracePeriod }}
-      eviction-hard: {{ .spec.hardEvictionThresholds | default .Values.internal.defaults.hardEvictionThresholds }}
-      eviction-minimum-reclaim: {{ .Values.controlPlane.evictionMinimumReclaim | default .Values.internal.defaults.evictionMinimumReclaim }}
+      eviction-soft: {{ .Values.internal.defaults.softEvictionThresholds }}
+      eviction-soft-grace-period: {{ .Values.internal.defaults.softEvictionGracePeriod }}
+      eviction-hard: {{ .Values.internal.defaults.hardEvictionThresholds }}
+      eviction-minimum-reclaim: {{ .Values.internal.defaults.evictionMinimumReclaim }}
       node-labels: role=worker,giantswarm.io/machine-{{ternary "pool" "deployment" (eq .type "machinePool")}}={{ include "resource.default.name" $ }}-{{ .spec.name }}{{- if (and (hasKey .spec "customNodeLabels") (gt (len .spec.customNodeLabels) 0) ) }},{{- join "," .spec.customNodeLabels }}{{- end }}
     name: '{{ `{{ ds.meta_data.local_hostname }}` }}'
     {{- if .spec.customNodeTaints }}


### PR DESCRIPTION
pinging @marians  for reference 

Removing the support for changing `eviciton` settings on a per node basis so we don't need to expose this option to the customer in the UI and in the schema

