### PR TITLE
Values schema: move /kubernetesVersion into /internal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Moved /attachCapzControllerIdentity into /internal/identy
   - Moved /enablePerClusterIdentity into /internal/identy
   - Moved /sshSSOPublicKey to /connectivity/sshSSOPublicKey
+  - Moved /kubernetesVersion to /internal/kubernetesVersion
 
 ### Removed
 

--- a/helm/cluster-azure/templates/_bastion.tpl
+++ b/helm/cluster-azure/templates/_bastion.tpl
@@ -70,7 +70,7 @@ spec:
         apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
         kind: AzureMachineTemplate
         name: {{ include "resource.default.name" $ }}-{{ $spec.name }}-{{ $azureMachineTemplateHash.hash }}
-      version: {{ $.Values.kubernetesVersion }}
+      version: {{ $.Values.internal.kubernetesVersion }}
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: AzureMachineTemplate

--- a/helm/cluster-azure/templates/_kcp.tpl
+++ b/helm/cluster-azure/templates/_kcp.tpl
@@ -204,7 +204,7 @@ spec:
     users:
     {{- include "sshUsers" . | nindent 6 }}
   replicas: {{ .Values.controlPlane.replicas | default "3" }}
-  version: {{ .Values.kubernetesVersion }}
+  version: {{ .Values.internal.kubernetesVersion }}
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: AzureMachineTemplate

--- a/helm/cluster-azure/templates/_machine_deployments.tpl
+++ b/helm/cluster-azure/templates/_machine_deployments.tpl
@@ -31,7 +31,7 @@ spec:
         apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
         kind: AzureMachineTemplate
         name: {{ include "resource.default.name" $ }}-{{ .name }}-{{ $azureMachineTemplateHash.hash }}
-      version: {{ $.Values.kubernetesVersion }}
+      version: {{ $.Values.internal.kubernetesVersion }}
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: AzureMachineTemplate

--- a/helm/cluster-azure/templates/_machine_pool.tpl
+++ b/helm/cluster-azure/templates/_machine_pool.tpl
@@ -26,7 +26,7 @@ spec:
         apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
         kind: AzureMachinePool
         name: {{ include "resource.default.name" $ }}-{{ .name }}
-      version: {{ $.Values.kubernetesVersion }}
+      version: {{ $.Values.internal.kubernetesVersion }}
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: AzureMachinePool

--- a/helm/cluster-azure/values.schema.json
+++ b/helm/cluster-azure/values.schema.json
@@ -146,14 +146,14 @@
                     },
                     "title": "Identity",
                     "type": "object"
+                },
+                "kubernetesVersion": {
+                    "title": "Kubernetes version",
+                    "type": "string"
                 }
             },
             "title": "Internal settings",
             "type": "object"
-        },
-        "kubernetesVersion": {
-            "title": "Kubernetes version",
-            "type": "string"
         },
         "machineDeployments": {
             "items": {

--- a/helm/cluster-azure/values.yaml
+++ b/helm/cluster-azure/values.yaml
@@ -8,8 +8,6 @@ metadata:
   # Organization in which to create the cluster.
   organization: ""
 
-kubernetesVersion: 1.24.8
-
 providerSpecific:
   location: "westeurope"
   # This value must be updated to the right value for the cluster to be installed
@@ -86,3 +84,4 @@ internal:
     # TODO: This is temporary so we can deploy clusters without dedicated UA Identity until the operator for WC clusters are ready
     # https://github.com/giantswarm/giantswarm/issues/25039
     enablePerClusterIdentity: false
+  kubernetesVersion: 1.24.8


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/1990

As discussed in [Slack](https://gigantic.slack.com/archives/C01F7T2MNRL/p1676025016779299), the value should not be exposed to end-users, so it's going to /internal.
