### PR TITLE
Values schema: remove /includeClusterResourceSet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
-- Values schema: removed redundant and unused /clusterName and /clusterDescription properties.
+- Values schema
+  - Removed redundant and unused /clusterName and /clusterDescription properties.
+  - Removed unused /includeClusterResourceSet
 
 ## [0.0.6] - 2023-02-08
 

--- a/helm/cluster-azure/values.schema.json
+++ b/helm/cluster-azure/values.schema.json
@@ -104,11 +104,6 @@
             "title": "Control plane settings",
             "type": "object"
         },
-        "includeClusterResourceSet": {
-            "description": "If true, a ClusterResourceSet resource is generated for the cluster.",
-            "title": "Include ClusterResourceSet",
-            "type": "boolean"
-        },
         "internal": {
             "properties": {
                 "defaults": {

--- a/helm/cluster-azure/values.yaml
+++ b/helm/cluster-azure/values.yaml
@@ -27,6 +27,7 @@ connectivity:
     podCidr: "192.168.0.0/16"
     hostCidr: "10.0.0.0/8"
     mode: public
+  sshSSOPublicKey: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIM4cvZ01fLmO9cJbWUj7sfF+NhECgy+Cl0bazSrZX7sU vault-ca@vault.operations.giantswarm.io"
 
 controlPlane:
   instanceType: Standard_D4s_v3
@@ -66,9 +67,6 @@ machineDeployments:
     # - key: ""
     #   value: ""
     #   effect: "" # Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
-
-
-sshSSOPublicKey: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIM4cvZ01fLmO9cJbWUj7sfF+NhECgy+Cl0bazSrZX7sU vault-ca@vault.operations.giantswarm.io"
 
 internal:
   defaults:

--- a/helm/cluster-azure/values.yaml
+++ b/helm/cluster-azure/values.yaml
@@ -70,9 +70,6 @@ machineDeployments:
 
 sshSSOPublicKey: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIM4cvZ01fLmO9cJbWUj7sfF+NhECgy+Cl0bazSrZX7sU vault-ca@vault.operations.giantswarm.io"
 
-# Used by `cluster-shared` library chart
-includeClusterResourceSet: true
-
 internal:
   defaults:
     softEvictionThresholds: memory.available<500Mi,nodefs.available<15%,nodefs.inodesFree<5%,imagefs.available<15%,pid.available<30%

--- a/helm/cluster-azure/values.yaml
+++ b/helm/cluster-azure/values.yaml
@@ -27,7 +27,6 @@ connectivity:
     podCidr: "192.168.0.0/16"
     hostCidr: "10.0.0.0/8"
     mode: public
-  sshSSOPublicKey: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIM4cvZ01fLmO9cJbWUj7sfF+NhECgy+Cl0bazSrZX7sU vault-ca@vault.operations.giantswarm.io"
 
 controlPlane:
   instanceType: Standard_D4s_v3
@@ -67,6 +66,9 @@ machineDeployments:
     # - key: ""
     #   value: ""
     #   effect: "" # Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+
+
+sshSSOPublicKey: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIM4cvZ01fLmO9cJbWUj7sfF+NhECgy+Cl0bazSrZX7sU vault-ca@vault.operations.giantswarm.io"
 
 internal:
   defaults:


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/1990

As we found out, the `/includeClusterResourceSet` value is not effective due to the way it's implemented in `cluster-shared`.

This removal is based on the assumption that the setting is not needed anyway.