### PR TITLE
Move default value for sshSSOPublicKey

### DIFF
--- a/helm/cluster-azure/values.yaml
+++ b/helm/cluster-azure/values.yaml
@@ -27,6 +27,7 @@ connectivity:
     podCidr: "192.168.0.0/16"
     hostCidr: "10.0.0.0/8"
     mode: public
+  sshSSOPublicKey: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIM4cvZ01fLmO9cJbWUj7sfF+NhECgy+Cl0bazSrZX7sU vault-ca@vault.operations.giantswarm.io"
 
 controlPlane:
   instanceType: Standard_D4s_v3
@@ -66,9 +67,6 @@ machineDeployments:
     # - key: ""
     #   value: ""
     #   effect: "" # Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
-
-
-sshSSOPublicKey: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIM4cvZ01fLmO9cJbWUj7sfF+NhECgy+Cl0bazSrZX7sU vault-ca@vault.operations.giantswarm.io"
 
 # Used by `cluster-shared` library chart
 includeClusterResourceSet: true


### PR DESCRIPTION
This fixes an oversight in https://github.com/giantswarm/cluster-azure/pull/55 where a value has changed its place in the schema, but not in the default values YAML file.