### PR TITLE
Disallow additional properties on the schema root level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Disallow additional properties on the values scherma root level.
+
+### Removed
+
+- Removed `baseDomain` from CI values.
+
 ## [0.0.7] - 2023-02-14
 
 ### Added
@@ -19,7 +27,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - **Breaking change** to values schema - make sure to update your values before updating to this releaseValues schema:
-  - Disallow additional properties on the root level
   - Renamed /azure to /providerSpecific
   - Moved /bastion to /connectivity/bastion
   - Moved /oidc to /controlPlane/oidc

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - **Breaking change** to values schema - make sure to update your values before updating to this releaseValues schema:
+  - Disallow additional properties on the root level
   - Renamed /azure to /providerSpecific
   - Moved /bastion to /connectivity/bastion
   - Moved /oidc to /controlPlane/oidc

--- a/helm/cluster-azure/ci/ci-values.yaml
+++ b/helm/cluster-azure/ci/ci-values.yaml
@@ -1,4 +1,3 @@
 metadata:
   organization: test
   servicePriority: lowest
-baseDomain: example.com

--- a/helm/cluster-azure/values.schema.json
+++ b/helm/cluster-azure/values.schema.json
@@ -3,6 +3,9 @@
     "additionalProperties": false,
     "description": "Configuration of an Azure cluster using Cluster API",
     "properties": {
+        "cluster-shared": {
+            "title": "Library chart"
+        },
         "connectivity": {
             "properties": {
                 "bastion": {

--- a/helm/cluster-azure/values.schema.json
+++ b/helm/cluster-azure/values.schema.json
@@ -1,5 +1,6 @@
 {
     "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "additionalProperties": false,
     "description": "Configuration of an Azure cluster using Cluster API",
     "properties": {
         "connectivity": {


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/1990

This PR adds `additionalProperties: false` on the root level of values, which means that only values defined in the schema can be used in values.