### PR TITLE
Add missing type

### DIFF
--- a/helm/cluster-azure/values.schema.json
+++ b/helm/cluster-azure/values.schema.json
@@ -4,7 +4,8 @@
     "description": "Configuration of an Azure cluster using Cluster API",
     "properties": {
         "cluster-shared": {
-            "title": "Library chart"
+            "title": "Library chart",
+            "type": "object"
         },
         "connectivity": {
             "properties": {


### PR DESCRIPTION
This adds the required type definition for the recently added `/cluster-shared` property. Unfortunately schemalint does not catch this yet.