### PR TITLE
Re-Add selector to machine deployments since is a required field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Update example manifests to create cluster
+- Re-Add selector to machineDeployment , this is a required field and the webhook validation fail without it ( only in our kind mc-bootstrap)
 
 ## [0.0.8] - 2023-02-15
 

--- a/helm/cluster-azure/templates/_machine_deployments.tpl
+++ b/helm/cluster-azure/templates/_machine_deployments.tpl
@@ -16,6 +16,8 @@ metadata:
 spec:
   clusterName: {{ include "resource.default.name" $ }}
   replicas: {{ .replicas }}
+  selector:
+    matchLabels: null
   template:
     metadata:
       labels:


### PR DESCRIPTION
when deploying through CAPI on kind ( for mc-bootstrap )
```
Error: unable to build kubernetes objects from release manifest: error validating "": error validating data: ValidationError(MachineDeployment.spec): missing required field "selector" in io.x-k8s.cluster.v1beta1.MachineDeployment.spec
```

this means that for some reason , probably still the `watch-cluster-filter` we are not validating some resources against the webhooks since on glippy this template did not fail the webhook validation  :disappointed: 

I will create an issue to investigate it once glippy is back up and running