### PR TITLE
Add properties that are not part of the APP but are defined by the APP operator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Add `managementCluster`, `baseDomain` and `provider` properties to the schema because they are added by the AppOperator and the schema has `additionalProperties: false`
+
 ## [0.0.10] - 2023-02-15
 
 ### Changed

--- a/helm/cluster-azure/values.schema.json
+++ b/helm/cluster-azure/values.schema.json
@@ -3,6 +3,10 @@
     "additionalProperties": false,
     "description": "Configuration of an Azure cluster using Cluster API",
     "properties": {
+        "baseDomain": {
+            "title": "The base dns domain",
+            "type": "string"
+        },
         "cluster-shared": {
             "title": "Library chart",
             "type": "object"
@@ -305,6 +309,10 @@
             "title": "Machine pools (deprecated)",
             "type": "array"
         },
+        "managementCluster": {
+            "title": "The capi MC managing this cluster",
+            "type": "string"
+        },
         "metadata": {
             "properties": {
                 "description": {
@@ -336,6 +344,10 @@
             },
             "title": "Metadata",
             "type": "object"
+        },
+        "provider": {
+            "title": "The capi Provider for this cluster",
+            "type": "string"
         },
         "providerSpecific": {
             "properties": {


### PR DESCRIPTION
@marians FYI

Those properties come from the extra values that the APP Operator add to all apps, including the `cluster-azure` one 

This is currently causing this error

```
status:
  appVersion: ""
  release:
    lastDeployed: null
    reason: |
      values don't meet the specifications of the schema(s) in the following chart(s):
      cluster-azure:
      - (root): Additional property managementCluster is not allowed
      - (root): Additional property baseDomain is not allowed
      - (root): Additional property provider is not allowed
    status: not-installed
  version: ""

➜ k get cm -n giantswarm glippy-chart-values -o yaml | egrep -i "baseDomain|managementCluster|provider"
    baseDomain: test.gigantic.io
    managementCluster: glippy
    provider: capz
    providerSpecific:
```

But in the future might break cluster-azure ( or other provider ) apps if new values are added to the app operator so might be worth thinking about it if we Do want to `forbid unknown values` from being defined 