### PR TITLE
Add support for SystemAssigned identities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Add support for creating WC with SystemAssigned Identities and make it the default - `Contributor` Role in the `resourceGroup` where the cluster Lives
+
 ## [0.0.14] - 2023-03-08
 
 ### Changed

--- a/examples/cluster-default/01_configmaps.yaml
+++ b/examples/cluster-default/01_configmaps.yaml
@@ -10,8 +10,6 @@ data:
       location: "westeurope"
       #This is the GHOST subscription
       subscriptionId: 6b1f6e4a-6d0e-4aa4-9a5a-fbaca65a23b3
-      azureClusterIdentity:
-        name: "cluster-identity-static-sp"
 
     nodePools:
     - name: md00

--- a/examples/cluster-default/02_apps.yaml
+++ b/examples/cluster-default/02_apps.yaml
@@ -16,7 +16,7 @@ spec:
     configMap:
       name: cluster01-user-values
       namespace: org-multi-project
-  version: 0.0.14
+  version: 0.0.15
 ---
 apiVersion: application.giantswarm.io/v1alpha1
 kind: App

--- a/helm/cluster-azure/templates/_bastion.tpl
+++ b/helm/cluster-azure/templates/_bastion.tpl
@@ -1,5 +1,6 @@
 {{- define "bastion-machine-identity" -}}
-identity: SystemAssigned
+identity: UserAssigned
+userAssignedIdentities: []
 {{- end -}}
 
 {{- define "bastion-machine-spec" -}}

--- a/helm/cluster-azure/templates/_bastion.tpl
+++ b/helm/cluster-azure/templates/_bastion.tpl
@@ -1,6 +1,5 @@
 {{- define "bastion-machine-identity" -}}
 identity: SystemAssigned
-systemAssignedIdentityRole: {}
 {{- end -}}
 
 {{- define "bastion-machine-spec" -}}

--- a/helm/cluster-azure/templates/_bastion.tpl
+++ b/helm/cluster-azure/templates/_bastion.tpl
@@ -1,9 +1,6 @@
 {{- define "bastion-machine-identity" -}}
-{{- if .Values.internal.identity.enablePerClusterIdentity -}}
-identity: UserAssigned
-userAssignedIdentities:
-  - providerID: {{ include "vmUaIdentityPrefix" $ }}-nodes {{/* TODO Review this identity, with SA Identity we can set it to empty */}}
-{{ end -}}
+identity: SystemAssigned
+systemAssignedIdentityRole: {}
 {{- end -}}
 
 {{- define "bastion-machine-spec" -}}

--- a/helm/cluster-azure/templates/_bastion.tpl
+++ b/helm/cluster-azure/templates/_bastion.tpl
@@ -1,7 +1,9 @@
 {{- define "bastion-machine-identity" -}}
+{{/* We need to set a role, set a very low priviliged for now (Workbook Reader) and TODO Look into this */}}
 identity: SystemAssigned
 systemAssignedIdentityRole:
-  name: {{ include "resource.default.name" $ }}-{{ $.spec.name }}
+  scope: /subscriptions/{{ $.Values.providerSpecific.subscriptionId }}/resourceGroups/{{ include "resource.default.name" $ }}
+  definitionID: /subscriptions/{{ $.Values.providerSpecific.subscriptionId }}/providers/Microsoft.Authorization/roleDefinitions/b279062a-9be3-42a0-92ae-8b3cf002ec4d
 {{- end -}}
 
 {{- define "bastion-machine-spec" -}}

--- a/helm/cluster-azure/templates/_bastion.tpl
+++ b/helm/cluster-azure/templates/_bastion.tpl
@@ -1,6 +1,7 @@
 {{- define "bastion-machine-identity" -}}
-identity: UserAssigned
-userAssignedIdentities: []
+identity: SystemAssigned
+systemAssignedIdentityRole:
+  name: {{ include "resource.default.name" $ }}-{{ $.spec.name }}
 {{- end -}}
 
 {{- define "bastion-machine-spec" -}}

--- a/helm/cluster-azure/templates/_kcp.tpl
+++ b/helm/cluster-azure/templates/_kcp.tpl
@@ -1,12 +1,6 @@
 {{- define "controlplane-azuremachinetemplate-spec" -}}
-{{- if .Values.internal.identity.enablePerClusterIdentity -}}
-identity: UserAssigned
-userAssignedIdentities:
-  - providerID: {{ include "vmUaIdentityPrefix" $ }}-cp
-  {{- if .Values.internal.identity.attachCapzControllerIdentity }}
-  - providerID: {{ include "vmUaIdentityPrefix" $ }}-capz
-  {{- end }}
-{{ end -}}
+{{ $identity := dict "type" "controlPlane" "Values" $.Values "Release" $.Release }}
+{{- include "renderIdentityConfiguration" $identity }}
 image:
   computeGallery:
     gallery: {{  $.Values.internal.image.gallery }}

--- a/helm/cluster-azure/templates/_machine_deployments.tpl
+++ b/helm/cluster-azure/templates/_machine_deployments.tpl
@@ -2,7 +2,7 @@
 {{- range $nodePool := .Values.nodePools }}
 {{ $data := dict "spec" ( merge $nodePool ( dict  "type" "machineDeployment" ) ) "Values" $.Values "Release" $.Release "Files" $.Files "Template" $.Template }}
 {{ $kubeAdmConfigTemplateHash := dict "hash" ( include "hash" (dict "data" (include "machine-kubeadmconfig-spec" $data) "global" $) ) }}
-{{ $azureMachineTemplateHash := dict "hash" ( include "hash" (dict "data" ( dict "spec" (include "machine-spec" $data) "identity" (include "machine-identity" $data) ) "global" $) ) }}
+{{ $azureMachineTemplateHash := dict "hash" ( include "hash" (dict "data" ( dict "spec" (include "machine-spec" $data) "identity" (include "renderIdentityConfiguration" $data) ) "global" $) ) }}
 apiVersion: cluster.x-k8s.io/v1beta1
 kind: MachineDeployment
 metadata:
@@ -49,7 +49,7 @@ spec:
       labels:
         {{- include "labels.common" $ | nindent 8 }}
     spec:
-      {{- include "machine-identity" $data | nindent 6}}
+      {{- include "renderIdentityConfiguration" $data | nindent 6}}
       {{- include "machine-spec" $data | nindent 6}}
 ---
 apiVersion: bootstrap.cluster.x-k8s.io/v1beta1

--- a/helm/cluster-azure/templates/_machine_helpers.tpl
+++ b/helm/cluster-azure/templates/_machine_helpers.tpl
@@ -2,17 +2,6 @@
 Helpers to reuse when defining specs for MachinePools and MachineDeployments
 */}}
 
-{{- define "machine-identity" -}}
-{{- if .Values.internal.identity.enablePerClusterIdentity -}}
-identity: UserAssigned
-userAssignedIdentities:
-  - providerID: {{ include "vmUaIdentityPrefix" $ }}-cp
-  {{- if .Values.internal.identity.attachCapzControllerIdentity }}
-  - providerID: {{ include "vmUaIdentityPrefix" $ }}-capz
-  {{- end }}
-{{ end -}}
-{{- end -}}
-
 {{- define "machine-spec" -}}
 image:
   computeGallery:

--- a/helm/cluster-azure/templates/_machine_pool.tpl
+++ b/helm/cluster-azure/templates/_machine_pool.tpl
@@ -38,7 +38,7 @@ metadata:
   name: {{ include "resource.default.name" $ }}-{{ .name }}
   namespace: {{ $.Release.Namespace }}
 spec:
-  {{- include "machine-identity" $data | nindent 2}}
+  {{- include "renderIdentityConfiguration" $data | nindent 2}}
   location: {{ $.Values.providerSpecific.location }}
   strategy:
     rollingUpdate:

--- a/helm/cluster-azure/values.schema.json
+++ b/helm/cluster-azure/values.schema.json
@@ -183,15 +183,24 @@
                 },
                 "identity": {
                     "properties": {
-                        "attachCapzControllerIdentity": {
+                        "attachCapzControllerUserAssignedIdentity": {
                             "default": false,
-                            "title": "Attach controller identity",
+                            "title": "Attach CAPZ controller UserAssigned identity",
                             "type": "boolean"
                         },
-                        "enablePerClusterIdentity": {
-                            "default": false,
-                            "title": "Enable identity per cluster",
-                            "type": "boolean"
+                        "type": {
+                            "default": "SystemAssigned",
+                            "enum": [
+                                "SystemAssigned",
+                                "UserAssigned"
+                            ],
+                            "title": "Type of Identity",
+                            "type": "string"
+                        },
+                        "userAssignedCustomIdentities": {
+                            "default": [],
+                            "title": "List of custom UserAssigned Identities to attach to all nodes",
+                            "type": "array"
                         }
                     },
                     "title": "Identity",

--- a/helm/cluster-azure/values.yaml
+++ b/helm/cluster-azure/values.yaml
@@ -31,8 +31,9 @@ internal:
     softEvictionGracePeriod: memory.available=30s,nodefs.available=2m,nodefs.inodesFree=1m,imagefs.available=2m,pid.available=1m
     softEvictionThresholds: memory.available<500Mi,nodefs.available<15%,nodefs.inodesFree<5%,imagefs.available<15%,pid.available<30%
   identity:
-    attachCapzControllerIdentity: false
-    enablePerClusterIdentity: false
+    attachCapzControllerUserAssignedIdentity: false
+    type: SystemAssigned
+    userAssignedCustomIdentities: []
   image:
     gallery: gsCapzFlatcar-41c2d140-ac44-4d8b-b7e1-7b2f1ddbe4d0
     name: ""


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/24578

## ToDo

* find the best way to assign no role or minimum possible role for Bastion
* [ ] Updating Glippy will require changes to the `values configmap` 
* [ ] Update in lastpass `default-values.yaml` and `glippy-values.yaml`

## ToTest

* [x] Test create cluster with default UA CAPZ identity `AzureClusterIdentity`  setting `SystemAssigned` identity on the WC 
* [x] Check Assigned identity on CP and Worker Nodes 
* [x] Validate `azure.json` file 
* [x] Validate Cloud Controllers are successfully doint what they need
  * [x] Create and delete a PVC 
  * [x] Create and delete a disk snapshot
  * [x] Create a `Service Loadbalancer` 
  * [x] external-dns
* [x] ~~Test upgrade of WC cluster from SP to SystemAssigned~~ - don't need this 
* [x] Ensure MC Rendering is the same as now 
