### PR TITLE
Add private clusters support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add support for private clusters.
+
 ## [0.0.16] - 2023-03-27
+
 ### Added
 
 - Add support for failuredomains field to MachineDeployments

--- a/helm/cluster-azure/templates/_azure_cluster.tpl
+++ b/helm/cluster-azure/templates/_azure_cluster.tpl
@@ -59,7 +59,7 @@ spec:
       {{- end}}
       {{- end }}
     {{- if (eq .Values.connectivity.network.mode "private") }}
-    privateDNSZoneName: {{ .Values.internal.privateDNSZoneName }}
+    privateDNSZoneName: "{{ include "resource.default.name" $ }}.{{ .Values.baseDomain }}"
     apiServerLB:
       name: {{ include "resource.default.name" $ }}-api-internal-lb
       type: Internal

--- a/helm/cluster-azure/templates/_azure_cluster.tpl
+++ b/helm/cluster-azure/templates/_azure_cluster.tpl
@@ -65,7 +65,7 @@ spec:
       type: Internal
       frontendIPs:
       - name: {{ include "resource.default.name" $ }}-api-internal-lb-ip
-        privateIP: {{ .Values.connectivity.network.controlPlane.apiServerLbIp }}
+        privateIP: "{{- include "controlPlane.apiServerLbIp" .Values.connectivity.network.controlPlane.cidr | trim -}}"
     controlPlaneOutboundLB:
       frontendIPsCount: 1
     {{end}}

--- a/helm/cluster-azure/templates/_azure_cluster.tpl
+++ b/helm/cluster-azure/templates/_azure_cluster.tpl
@@ -31,32 +31,8 @@ spec:
       name: {{ include "resource.default.name" $ }}-vnet
       cidrBlocks:
       - {{ .Values.connectivity.network.hostCidr }}
-      {{- if .Values.providerSpecific.network.peerings }}
-      peerings:
-      {{- range .Values.providerSpecific.network.peerings }}
-      - resourceGroup: {{ .resourceGroup }}
-        remoteVnetName: {{ .remoteVnetName }}
-        {{- if (eq $.Values.connectivity.network.mode "private") }}
-        forwardPeeringProperties:
-          allowForwardedTraffic: true
-          {{- if (eq $.Values.internal.network.vpn.gatewayMode "remote") }}
-          allowGatewayTransit: false
-          useRemoteGateways: true
-          {{- else }}
-          allowGatewayTransit: true
-          useRemoteGateways: false
-          {{ end }}
-        reversePeeringProperties:
-          allowForwardedTraffic: true
-          {{- if (eq $.Values.internal.network.vpn.gatewayMode "remote") }}
-          allowGatewayTransit: true
-          useRemoteGateways: false
-          {{- else }}
-          allowGatewayTransit: false
-          useRemoteGateways: true
-          {{ end }}
-        {{- end }}
-      {{- end}}
+      {{- if (include "providerSpecific.vnetPeerings" $) }}
+      peering: {{- include "providerSpecific.vnetPeerings" $ | indent 6 }}
       {{- end }}
     {{- if (eq .Values.connectivity.network.mode "private") }}
     privateDNSZoneName: "{{ include "resource.default.name" $ }}.{{ .Values.baseDomain }}"

--- a/helm/cluster-azure/templates/_azure_cluster.tpl
+++ b/helm/cluster-azure/templates/_azure_cluster.tpl
@@ -35,7 +35,7 @@ spec:
       peerings: {{ toYaml .Values.providerSpecific.network.peerings | nindent 6 }}
       {{- end }}
     {{- if (eq .Values.connectivity.network.mode "private") }}
-    privateDNSZoneName: {{ .Values.providerSpecific.network.privateDNSZoneName }}
+    privateDNSZoneName: {{ .Values.internal.privateDNSZoneName }}
     apiServerLB:
       name: {{ include "resource.default.name" $ }}-api-internal-lb
       type: Internal

--- a/helm/cluster-azure/templates/_azure_cluster.tpl
+++ b/helm/cluster-azure/templates/_azure_cluster.tpl
@@ -40,7 +40,8 @@ spec:
       name: {{ include "resource.default.name" $ }}-api-internal-lb
       type: Internal
       frontendIPs:
-      - {{ .Values.connectivity.network.controlPlane.apiServerLbIp }}
+      - name: {{ include "resource.default.name" $ }}-api-internal-lb-ip
+        privateIP: {{ .Values.connectivity.network.controlPlane.apiServerLbIp }}
     controlPlaneOutboundLB:
       name: {{ include "resource.default.name" $ }}-control-plane-outbound-lb
       type: Public

--- a/helm/cluster-azure/templates/_azure_cluster.tpl
+++ b/helm/cluster-azure/templates/_azure_cluster.tpl
@@ -21,9 +21,7 @@ spec:
         - {{ .Values.connectivity.network.controlPlane.cidr }}
       - name: node-subnet
         natGateway:
-          name: {{ include "resource.default.name" $ }}-node-natgateway
-          NatGatewayIP:
-            name: {{ include "resource.default.name" $ }}-node-natgateway-ip
+          name: node-natgateway
         role: node
         cidrBlocks:
         - {{ .Values.connectivity.network.workers.cidr }}

--- a/helm/cluster-azure/templates/_azure_cluster.tpl
+++ b/helm/cluster-azure/templates/_azure_cluster.tpl
@@ -32,7 +32,7 @@ spec:
       cidrBlocks:
       - {{ .Values.connectivity.network.hostCidr }}
       {{- if (include "providerSpecific.vnetPeerings" $) }}
-      peering: {{- include "providerSpecific.vnetPeerings" $ | indent 6 }}
+      peerings: {{- include "providerSpecific.vnetPeerings" $ | indent 6 }}
       {{- end }}
     {{- if (eq .Values.connectivity.network.mode "private") }}
     privateDNSZoneName: "{{ include "resource.default.name" $ }}.{{ .Values.baseDomain }}"

--- a/helm/cluster-azure/templates/_azure_cluster.tpl
+++ b/helm/cluster-azure/templates/_azure_cluster.tpl
@@ -38,7 +38,7 @@ spec:
       name: {{ include "resource.default.name" $ }}-api-internal-lb
       type: Internal
       frontendIPs:
-      - name: {{ include "resource.default.name" $ }}-api-internal-lb-ip
+      - name: {{ include "resource.default.name" $ }}-api-internal-lb-frontend-ip
         privateIP: "{{- include "controlPlane.apiServerLbIp" .Values.connectivity.network.controlPlane.cidr | trim -}}"
     controlPlaneOutboundLB:
       frontendIPsCount: 1

--- a/helm/cluster-azure/templates/_azure_cluster.tpl
+++ b/helm/cluster-azure/templates/_azure_cluster.tpl
@@ -32,7 +32,31 @@ spec:
       cidrBlocks:
       - {{ .Values.connectivity.network.hostCidr }}
       {{- if .Values.providerSpecific.network.peerings }}
-      peerings: {{ toYaml .Values.providerSpecific.network.peerings | nindent 6 }}
+      peerings:
+      {{- range .Values.providerSpecific.network.peerings }}
+      - resourceGroup: {{ .resourceGroup }}
+        remoteVnetName: {{ .remoteVnetName }}
+        {{- if (eq $.Values.connectivity.network.mode "private") }}
+        forwardPeeringProperties:
+          allowForwardedTraffic: true
+          {{- if (eq $.Values.internal.network.vpn.gatewayMode "remote") }}
+          allowGatewayTransit: false
+          useRemoteGateways: true
+          {{- else }}
+          allowGatewayTransit: true
+          useRemoteGateways: false
+          {{ end }}
+        reversePeeringProperties:
+          allowForwardedTraffic: true
+          {{- if (eq $.Values.internal.network.vpn.gatewayMode "remote") }}
+          allowGatewayTransit: true
+          useRemoteGateways: false
+          {{- else }}
+          allowGatewayTransit: false
+          useRemoteGateways: true
+          {{ end }}
+        {{- end }}
+      {{- end}}
       {{- end }}
     {{- if (eq .Values.connectivity.network.mode "private") }}
     privateDNSZoneName: {{ .Values.internal.privateDNSZoneName }}

--- a/helm/cluster-azure/templates/_azure_cluster.tpl
+++ b/helm/cluster-azure/templates/_azure_cluster.tpl
@@ -44,11 +44,9 @@ spec:
         privateIP: {{ .Values.connectivity.network.controlPlane.apiServerLbIp }}
     controlPlaneOutboundLB:
       name: {{ include "resource.default.name" $ }}-control-plane-outbound-lb
-      type: Public
       frontendIPsCount: 1
     nodeOutboundLB:
       name: {{ include "resource.default.name" $ }}-node-outbound-lb
-      type: Public
       frontendIPsCount: 1
     {{end}}
   resourceGroup: {{ include "resource.default.name" $ }}

--- a/helm/cluster-azure/templates/_azure_cluster.tpl
+++ b/helm/cluster-azure/templates/_azure_cluster.tpl
@@ -21,7 +21,9 @@ spec:
         - {{ .Values.connectivity.network.controlPlane.cidr }}
       - name: node-subnet
         natGateway:
-          name: node-natgateway
+          name: {{ include "resource.default.name" $ }}-node-natgateway
+          NatGatewayIP:
+            name: {{ include "resource.default.name" $ }}-node-natgateway-ip
         role: node
         cidrBlocks:
         - {{ .Values.connectivity.network.workers.cidr }}
@@ -29,6 +31,25 @@ spec:
       name: {{ include "resource.default.name" $ }}-vnet
       cidrBlocks:
       - {{ .Values.connectivity.network.hostCidr }}
+      {{- if .Values.providerSpecific.network.peerings }}
+      peerings: {{ toYaml .Values.providerSpecific.network.peerings | nindent 6 }}
+      {{- end }}
+    {{- if (eq .Values.connectivity.network.mode "private") }}
+    privateDNSZoneName: {{ .Values.providerSpecific.network.privateDNSZoneName }}
+    apiServerLB:
+      name: {{ include "resource.default.name" $ }}-api-internal-lb
+      type: Internal
+      frontendIPs:
+      - {{ .Values.connectivity.network.controlPlane.apiServerLbIp }}
+    controlPlaneOutboundLB:
+      name: {{ include "resource.default.name" $ }}-control-plane-outbound-lb
+      type: Public
+      frontendIPsCount: 1
+    nodeOutboundLB:
+      name: {{ include "resource.default.name" $ }}-node-outbound-lb
+      type: Public
+      frontendIPsCount: 1
+    {{end}}
   resourceGroup: {{ include "resource.default.name" $ }}
   subscriptionID: {{ .Values.providerSpecific.subscriptionId }}
 {{ end }}

--- a/helm/cluster-azure/templates/_azure_cluster.tpl
+++ b/helm/cluster-azure/templates/_azure_cluster.tpl
@@ -43,10 +43,8 @@ spec:
       - name: {{ include "resource.default.name" $ }}-api-internal-lb-ip
         privateIP: {{ .Values.connectivity.network.controlPlane.apiServerLbIp }}
     controlPlaneOutboundLB:
-      name: {{ include "resource.default.name" $ }}-control-plane-outbound-lb
       frontendIPsCount: 1
     nodeOutboundLB:
-      name: {{ include "resource.default.name" $ }}-node-outbound-lb
       frontendIPsCount: 1
     {{end}}
   resourceGroup: {{ include "resource.default.name" $ }}

--- a/helm/cluster-azure/templates/_azure_cluster.tpl
+++ b/helm/cluster-azure/templates/_azure_cluster.tpl
@@ -68,8 +68,6 @@ spec:
         privateIP: {{ .Values.connectivity.network.controlPlane.apiServerLbIp }}
     controlPlaneOutboundLB:
       frontendIPsCount: 1
-    nodeOutboundLB:
-      frontendIPsCount: 1
     {{end}}
   resourceGroup: {{ include "resource.default.name" $ }}
   subscriptionID: {{ .Values.providerSpecific.subscriptionId }}

--- a/helm/cluster-azure/templates/_helpers.tpl
+++ b/helm/cluster-azure/templates/_helpers.tpl
@@ -155,14 +155,32 @@ List of admission plugins to enable based on apiVersion
 {{- end -}}
 
 {{- define "kubeadm.controlPlane.privateNetwork.preCommands" -}}
+- if [ -f /tmp/kubeadm.yaml ]; then echo 'found /tmp/kubeadm.yaml' >> /tmp/cluster-azure.log; else echo 'not found /tmp/kubeadm.yaml' >> /tmp/cluster-azure.log; fi
+- if [ -f /run/kubeadm/kubeadm.yaml ]; then echo 'found /run/kubeadm/kubeadm.yaml' >> /tmp/cluster-azure.log; else echo 'not found /run/kubeadm/kubeadm.yaml' >> /tmp/cluster-azure.log; fi
+- if [ -f /etc/kubeadm.yml ]; then echo 'found /etc/kubeadm.yml' >> /tmp/cluster-azure.log; else echo 'not found /etc/kubeadm.yml' >> /tmp/cluster-azure.log; fi
+- echo '---------- hosts before change' >> /tmp/cluster-azure.log
+- cat /etc/hosts >> /tmp/cluster-azure.log
+- echo '----------' >> /tmp/cluster-azure.log
 - if [ -f /tmp/kubeadm.yaml ] || [ -f /run/kubeadm/kubeadm.yaml ]; then echo '127.0.0.1   apiserver.{{ .Values.internal.privateDNSZoneName }}
   apiserver' >> /etc/hosts; fi
+- echo '---------- hosts after change' >> /tmp/cluster-azure.log
+- cat /etc/hosts >> /tmp/cluster-azure.log
+- echo '----------' >> /tmp/cluster-azure.log
 {{- end -}}
 
 {{- define "kubeadm.controlPlane.privateNetwork.postCommands" -}}
+- if [ -f /tmp/kubeadm-join-config.yaml ]; then echo 'found /tmp/kubeadm-join-config.yaml' >> /tmp/cluster-azure.log; else echo 'not found /tmp/kubeadm-join-config.yaml' >> /tmp/cluster-azure.log; fi
+- if [ -f /run/kubeadm/kubeadm-join-config.yaml ]; then echo 'found /run/kubeadm/kubeadm-join-config.yaml' >> /tmp/cluster-azure.log; else echo 'not found /run/kubeadm/kubeadm-join-config.yaml' >> /tmp/cluster-azure.log; fi
+- if [ -f /etc/kubeadm-join-config.yaml ]; then echo 'found /etc/kubeadm-join-config.yaml' >> /tmp/cluster-azure.log; else echo 'not found /etc/kubeadm-join-config.yaml' >> /tmp/cluster-azure.log; fi
+- echo '---------- hosts before change' >> /tmp/cluster-azure.log
+- cat /etc/hosts >> /tmp/cluster-azure.log
+- echo '----------' >> /tmp/cluster-azure.log
 - if [ -f /tmp/kubeadm-join-config.yaml ] || [ -f /run/kubeadm/kubeadm-join-config.yaml
   ]; then echo '127.0.0.1   apiserver.{{ .Values.internal.privateDNSZoneName }}' >> /etc/hosts;
   fi
+- echo '---------- hosts after change' >> /tmp/cluster-azure.log
+- cat /etc/hosts >> /tmp/cluster-azure.log
+- echo '----------' >> /tmp/cluster-azure.log
 {{- end -}}
 
 {{- define "prepare-varLibKubelet-Dir" -}}

--- a/helm/cluster-azure/templates/_helpers.tpl
+++ b/helm/cluster-azure/templates/_helpers.tpl
@@ -154,6 +154,17 @@ List of admission plugins to enable based on apiVersion
 - /opt/bin/calculate_kubelet_reservations.sh
 {{- end -}}
 
+{{- define "kubeadm.controlPlane.privateNetwork.preCommands" -}}
+- if [ -f /tmp/kubeadm.yaml ] || [ -f /run/kubeadm/kubeadm.yaml ]; then echo '127.0.0.1   apiserver.{{ .Values.internal.privateDNSZoneName }}
+  apiserver' >> /etc/hosts; fi
+{{- end -}}
+
+{{- define "kubeadm.controlPlane.privateNetwork.postCommands" -}}
+- if [ -f /tmp/kubeadm-join-config.yaml ] || [ -f /run/kubeadm/kubeadm-join-config.yaml
+  ]; then echo '127.0.0.1   apiserver.{{ .Values.internal.privateDNSZoneName }}' >> /etc/hosts;
+  fi
+{{- end -}}
+
 {{- define "prepare-varLibKubelet-Dir" -}}
 - /bin/test ! -d /var/lib/kubelet && (/bin/mkdir -p /var/lib/kubelet && /bin/chmod 0750 /var/lib/kubelet)
 {{- end -}}

--- a/helm/cluster-azure/templates/_helpers.tpl
+++ b/helm/cluster-azure/templates/_helpers.tpl
@@ -267,7 +267,7 @@ It expects one argument which is the control plane subnet network range in forma
   Include peering from workload cluster to management cluster. This is added only to the WC VNets,
   which are peered to the MC VNMet (so checking that cluster name is different than MC name).
 */ -}}
-{{- if ne $.Values.metadata.name $.Values.managementCluster }}
+{{- if and (eq .Values.connectivity.network.mode "private") (ne $.Values.metadata.name $.Values.managementCluster) }}
 {{ include "providerSpecific.peeringFromWCToMC" $ }}
 {{- end }}
 

--- a/helm/cluster-azure/templates/_helpers.tpl
+++ b/helm/cluster-azure/templates/_helpers.tpl
@@ -155,26 +155,14 @@ List of admission plugins to enable based on apiVersion
 {{- end -}}
 
 {{- define "kubeadm.controlPlane.privateNetwork.preCommands" -}}
-- echo '---------- hosts before change' >> /tmp/cluster-azure.log
-- cat /etc/hosts >> /tmp/cluster-azure.log
-- echo '----------' >> /tmp/cluster-azure.log
 - if [ ! -z "$(grep "^kubeadm init*" "/etc/kubeadm.sh")" ]; then echo '127.0.0.1   apiserver.{{ .Values.internal.privateDNSZoneName }}
   apiserver' >> /etc/hosts; fi
-- echo '---------- hosts after change' >> /tmp/cluster-azure.log
-- cat /etc/hosts >> /tmp/cluster-azure.log
-- echo '----------' >> /tmp/cluster-azure.log
 {{- end -}}
 
 {{- define "kubeadm.controlPlane.privateNetwork.postCommands" -}}
-- echo '---------- hosts before change' >> /tmp/cluster-azure.log
-- cat /etc/hosts >> /tmp/cluster-azure.log
-- echo '----------' >> /tmp/cluster-azure.log
 - if [ ! -z "$(grep "^kubeadm join*" "/etc/kubeadm.sh")" ]; then
   echo '127.0.0.1   apiserver.{{ .Values.internal.privateDNSZoneName }}' >> /etc/hosts;
   fi
-- echo '---------- hosts after change' >> /tmp/cluster-azure.log
-- cat /etc/hosts >> /tmp/cluster-azure.log
-- echo '----------' >> /tmp/cluster-azure.log
 {{- end -}}
 
 {{- define "prepare-varLibKubelet-Dir" -}}

--- a/helm/cluster-azure/templates/_helpers.tpl
+++ b/helm/cluster-azure/templates/_helpers.tpl
@@ -155,15 +155,10 @@ List of admission plugins to enable based on apiVersion
 {{- end -}}
 
 {{- define "kubeadm.controlPlane.privateNetwork.preCommands" -}}
-- if [ -f /tmp/kubeadm.yaml ]; then echo 'found /tmp/kubeadm.yaml' >> /tmp/cluster-azure.log; else echo 'not found /tmp/kubeadm.yaml' >> /tmp/cluster-azure.log; fi
-- if [ -f /run/kubeadm/kubeadm.yaml ]; then echo 'found /run/kubeadm/kubeadm.yaml' >> /tmp/cluster-azure.log; else echo 'not found /run/kubeadm/kubeadm.yaml' >> /tmp/cluster-azure.log; fi
-- if [ -f /etc/kubeadm.yml ]; then echo 'found /etc/kubeadm.yml' >> /tmp/cluster-azure.log; else echo 'not found /etc/kubeadm.yml' >> /tmp/cluster-azure.log; fi
 - echo '---------- hosts before change' >> /tmp/cluster-azure.log
 - cat /etc/hosts >> /tmp/cluster-azure.log
 - echo '----------' >> /tmp/cluster-azure.log
-- if [ -f /tmp/kubeadm.yaml ] ||
-  [ -f /run/kubeadm/kubeadm.yaml ] ||
-  [ -f /etc/kubeadm.yml ]; then echo '127.0.0.1   apiserver.{{ .Values.internal.privateDNSZoneName }}
+- if [ ! -z "$(grep "^kubeadm init*" "/etc/kubeadm.sh")" ]; then echo '127.0.0.1   apiserver.{{ .Values.internal.privateDNSZoneName }}
   apiserver' >> /etc/hosts; fi
 - echo '---------- hosts after change' >> /tmp/cluster-azure.log
 - cat /etc/hosts >> /tmp/cluster-azure.log
@@ -171,16 +166,10 @@ List of admission plugins to enable based on apiVersion
 {{- end -}}
 
 {{- define "kubeadm.controlPlane.privateNetwork.postCommands" -}}
-- if [ -f /tmp/kubeadm-join-config.yaml ]; then echo 'found /tmp/kubeadm-join-config.yaml' >> /tmp/cluster-azure.log; else echo 'not found /tmp/kubeadm-join-config.yaml' >> /tmp/cluster-azure.log; fi
-- if [ -f /run/kubeadm/kubeadm-join-config.yaml ]; then echo 'found /run/kubeadm/kubeadm-join-config.yaml' >> /tmp/cluster-azure.log; else echo 'not found /run/kubeadm/kubeadm-join-config.yaml' >> /tmp/cluster-azure.log; fi
-- if [ -f /etc/kubeadm-join-config.yaml ]; then echo 'found /etc/kubeadm-join-config.yaml' >> /tmp/cluster-azure.log; else echo 'not found /etc/kubeadm-join-config.yaml' >> /tmp/cluster-azure.log; fi
-- if [ -f /etc/kubeadm-join-config.yml ]; then echo 'found /etc/kubeadm-join-config.yml' >> /tmp/cluster-azure.log; else echo 'not found /etc/kubeadm-join-config.yml' >> /tmp/cluster-azure.log; fi
 - echo '---------- hosts before change' >> /tmp/cluster-azure.log
 - cat /etc/hosts >> /tmp/cluster-azure.log
 - echo '----------' >> /tmp/cluster-azure.log
-- if [ -f /tmp/kubeadm-join-config.yaml ] ||
-  [ -f /run/kubeadm/kubeadm-join-config.yaml ] ||
-  [ -f /etc/kubeadm-join-config.yml ]; then
+- if [ ! -z "$(grep "^kubeadm join*" "/etc/kubeadm.sh")" ]; then
   echo '127.0.0.1   apiserver.{{ .Values.internal.privateDNSZoneName }}' >> /etc/hosts;
   fi
 - echo '---------- hosts after change' >> /tmp/cluster-azure.log

--- a/helm/cluster-azure/templates/_helpers.tpl
+++ b/helm/cluster-azure/templates/_helpers.tpl
@@ -161,7 +161,9 @@ List of admission plugins to enable based on apiVersion
 - echo '---------- hosts before change' >> /tmp/cluster-azure.log
 - cat /etc/hosts >> /tmp/cluster-azure.log
 - echo '----------' >> /tmp/cluster-azure.log
-- if [ -f /tmp/kubeadm.yaml ] || [ -f /run/kubeadm/kubeadm.yaml ]; then echo '127.0.0.1   apiserver.{{ .Values.internal.privateDNSZoneName }}
+- if [ -f /tmp/kubeadm.yaml ] ||
+  [ -f /run/kubeadm/kubeadm.yaml ] ||
+  [ -f /etc/kubeadm.yml ]; then echo '127.0.0.1   apiserver.{{ .Values.internal.privateDNSZoneName }}
   apiserver' >> /etc/hosts; fi
 - echo '---------- hosts after change' >> /tmp/cluster-azure.log
 - cat /etc/hosts >> /tmp/cluster-azure.log
@@ -172,11 +174,14 @@ List of admission plugins to enable based on apiVersion
 - if [ -f /tmp/kubeadm-join-config.yaml ]; then echo 'found /tmp/kubeadm-join-config.yaml' >> /tmp/cluster-azure.log; else echo 'not found /tmp/kubeadm-join-config.yaml' >> /tmp/cluster-azure.log; fi
 - if [ -f /run/kubeadm/kubeadm-join-config.yaml ]; then echo 'found /run/kubeadm/kubeadm-join-config.yaml' >> /tmp/cluster-azure.log; else echo 'not found /run/kubeadm/kubeadm-join-config.yaml' >> /tmp/cluster-azure.log; fi
 - if [ -f /etc/kubeadm-join-config.yaml ]; then echo 'found /etc/kubeadm-join-config.yaml' >> /tmp/cluster-azure.log; else echo 'not found /etc/kubeadm-join-config.yaml' >> /tmp/cluster-azure.log; fi
+- if [ -f /etc/kubeadm-join-config.yml ]; then echo 'found /etc/kubeadm-join-config.yml' >> /tmp/cluster-azure.log; else echo 'not found /etc/kubeadm-join-config.yml' >> /tmp/cluster-azure.log; fi
 - echo '---------- hosts before change' >> /tmp/cluster-azure.log
 - cat /etc/hosts >> /tmp/cluster-azure.log
 - echo '----------' >> /tmp/cluster-azure.log
-- if [ -f /tmp/kubeadm-join-config.yaml ] || [ -f /run/kubeadm/kubeadm-join-config.yaml
-  ]; then echo '127.0.0.1   apiserver.{{ .Values.internal.privateDNSZoneName }}' >> /etc/hosts;
+- if [ -f /tmp/kubeadm-join-config.yaml ] ||
+  [ -f /run/kubeadm/kubeadm-join-config.yaml ] ||
+  [ -f /etc/kubeadm-join-config.yml ]; then
+  echo '127.0.0.1   apiserver.{{ .Values.internal.privateDNSZoneName }}' >> /etc/hosts;
   fi
 - echo '---------- hosts after change' >> /tmp/cluster-azure.log
 - cat /etc/hosts >> /tmp/cluster-azure.log

--- a/helm/cluster-azure/templates/_helpers.tpl
+++ b/helm/cluster-azure/templates/_helpers.tpl
@@ -154,11 +154,19 @@ List of admission plugins to enable based on apiVersion
 - /opt/bin/calculate_kubelet_reservations.sh
 {{- end -}}
 
+{{/*
+Modify /etc/hosts in order to route API server requests to the local API server replica.
+See more details here https://github.com/giantswarm/roadmap/issues/2223.
+*/}}
 {{- define "kubeadm.controlPlane.privateNetwork.preCommands" -}}
 - if [ ! -z "$(grep "^kubeadm init*" "/etc/kubeadm.sh")" ]; then echo '127.0.0.1   apiserver.{{ include "resource.default.name" $ }}.{{ .Values.baseDomain }}
   apiserver' >> /etc/hosts; fi
 {{- end -}}
 
+{{/*
+Modify /etc/hosts in order to route API server requests to the local API server replica.
+See more details here https://github.com/giantswarm/roadmap/issues/2223.
+*/}}
 {{- define "kubeadm.controlPlane.privateNetwork.postCommands" -}}
 - if [ ! -z "$(grep "^kubeadm join*" "/etc/kubeadm.sh")" ]; then
   echo '127.0.0.1   apiserver.{{ include "resource.default.name" $ }}.{{ .Values.baseDomain }}' >> /etc/hosts;

--- a/helm/cluster-azure/templates/_helpers.tpl
+++ b/helm/cluster-azure/templates/_helpers.tpl
@@ -155,13 +155,13 @@ List of admission plugins to enable based on apiVersion
 {{- end -}}
 
 {{- define "kubeadm.controlPlane.privateNetwork.preCommands" -}}
-- if [ ! -z "$(grep "^kubeadm init*" "/etc/kubeadm.sh")" ]; then echo '127.0.0.1   apiserver.{{ .Values.internal.privateDNSZoneName }}
+- if [ ! -z "$(grep "^kubeadm init*" "/etc/kubeadm.sh")" ]; then echo '127.0.0.1   apiserver.{{ include "resource.default.name" $ }}.{{ .Values.baseDomain }}
   apiserver' >> /etc/hosts; fi
 {{- end -}}
 
 {{- define "kubeadm.controlPlane.privateNetwork.postCommands" -}}
 - if [ ! -z "$(grep "^kubeadm join*" "/etc/kubeadm.sh")" ]; then
-  echo '127.0.0.1   apiserver.{{ .Values.internal.privateDNSZoneName }}' >> /etc/hosts;
+  echo '127.0.0.1   apiserver.{{ include "resource.default.name" $ }}.{{ .Values.baseDomain }}' >> /etc/hosts;
   fi
 {{- end -}}
 

--- a/helm/cluster-azure/templates/_helpers.tpl
+++ b/helm/cluster-azure/templates/_helpers.tpl
@@ -223,3 +223,15 @@ userAssignedIdentities:
   {{- end -}}
 {{- end }}
 {{- end -}}
+
+{{/*
+Calculating API server load balancer IP based on control plane subnet CIDR.
+
+It expects one argument which is the control plane subnet network range in format "a.b.c.d/xx"
+*/}}
+{{- define "controlPlane.apiServerLbIp" -}}
+{{ $cidrParts := split "/" . }}
+{{ $ipParts := split "." $cidrParts._0 }}
+{{ $lastPart := $ipParts._3 | int | add 10 }}
+{{- $ipParts._0 -}}.{{- $ipParts._1 -}}.{{- $ipParts._2 -}}.{{- $lastPart -}}
+{{- end -}}

--- a/helm/cluster-azure/templates/_kcp.tpl
+++ b/helm/cluster-azure/templates/_kcp.tpl
@@ -233,7 +233,15 @@ spec:
     {{- include "prepare-varLibKubelet-Dir" . | nindent 6 }}
     {{- include "kubeletReservationPreCommands" . | nindent 6 }}
     {{- include "override-hostname-in-kubeadm-configuration" . | nindent 6 }}
+    {{- if (eq .Values.connectivity.network.mode "private") }}
+    {{- include "kubeadm.controlPlane.privateNetwork.preCommands" . | nindent 6 }}
+    {{- end }}
+    {{- if (eq .Values.connectivity.network.mode "private") }}
+    postKubeadmCommands:
+    {{- include "kubeadm.controlPlane.privateNetwork.postCommands" . | nindent 6 }}
+    {{- else }}
     postKubeadmCommands: []
+    {{ end }}
     users:
     {{- include "sshUsers" . | nindent 6 }}
   replicas: {{ .Values.controlPlane.replicas | default "3" }}

--- a/helm/cluster-azure/templates/_kcp.tpl
+++ b/helm/cluster-azure/templates/_kcp.tpl
@@ -230,15 +230,21 @@ spec:
         {{- include "customNodeTaints" .Values.controlPlane.customNodeTaints | indent 10 }}
         {{- end }}
     preKubeadmCommands:
+      - echo 'start preKubeadmCommands' >> /tmp/cluster-azure.log
     {{- include "prepare-varLibKubelet-Dir" . | nindent 6 }}
     {{- include "kubeletReservationPreCommands" . | nindent 6 }}
     {{- include "override-hostname-in-kubeadm-configuration" . | nindent 6 }}
+      - echo 'before /etc/hosts setup' >> /tmp/cluster-azure.log
     {{- if (eq .Values.connectivity.network.mode "private") }}
     {{- include "kubeadm.controlPlane.privateNetwork.preCommands" . | nindent 6 }}
+      - echo 'after /etc/hosts setup' >> /tmp/cluster-azure.log
     {{- end }}
+      - echo 'end preKubeadmCommands' >> /tmp/cluster-azure.log
     {{- if (eq .Values.connectivity.network.mode "private") }}
     postKubeadmCommands:
+      - echo 'start postKubeadmCommands' >> /tmp/cluster-azure.log
     {{- include "kubeadm.controlPlane.privateNetwork.postCommands" . | nindent 6 }}
+      - echo 'end postKubeadmCommands' >> /tmp/cluster-azure.log
     {{- else }}
     postKubeadmCommands: []
     {{ end }}

--- a/helm/cluster-azure/templates/_kcp.tpl
+++ b/helm/cluster-azure/templates/_kcp.tpl
@@ -89,6 +89,7 @@ spec:
           - 127.0.0.1
           - localhost
           - "api.{{ include "resource.default.name" $ }}.{{ .Values.baseDomain }}"
+          - "apiserver.{{ include "resource.default.name" $ }}.{{ .Values.baseDomain }}"
         extraArgs:
           {{- if .Values.controlPlane.serviceAccountIssuer }}
           service-account-issuer: {{ .Values.controlPlane.serviceAccountIssuer }}

--- a/helm/cluster-azure/templates/_kcp.tpl
+++ b/helm/cluster-azure/templates/_kcp.tpl
@@ -231,21 +231,15 @@ spec:
         {{- include "customNodeTaints" .Values.controlPlane.customNodeTaints | indent 10 }}
         {{- end }}
     preKubeadmCommands:
-      - echo 'start preKubeadmCommands' >> /tmp/cluster-azure.log
     {{- include "prepare-varLibKubelet-Dir" . | nindent 6 }}
     {{- include "kubeletReservationPreCommands" . | nindent 6 }}
     {{- include "override-hostname-in-kubeadm-configuration" . | nindent 6 }}
-      - echo 'before /etc/hosts setup' >> /tmp/cluster-azure.log
     {{- if (eq .Values.connectivity.network.mode "private") }}
     {{- include "kubeadm.controlPlane.privateNetwork.preCommands" . | nindent 6 }}
-      - echo 'after /etc/hosts setup' >> /tmp/cluster-azure.log
     {{- end }}
-      - echo 'end preKubeadmCommands' >> /tmp/cluster-azure.log
     {{- if (eq .Values.connectivity.network.mode "private") }}
     postKubeadmCommands:
-      - echo 'start postKubeadmCommands' >> /tmp/cluster-azure.log
     {{- include "kubeadm.controlPlane.privateNetwork.postCommands" . | nindent 6 }}
-      - echo 'end postKubeadmCommands' >> /tmp/cluster-azure.log
     {{- else }}
     postKubeadmCommands: []
     {{ end }}

--- a/helm/cluster-azure/values.schema.json
+++ b/helm/cluster-azure/values.schema.json
@@ -39,6 +39,13 @@
                                     "default": "10.0.0.0/20",
                                     "title": "Subnet",
                                     "type": "string"
+                                },
+                                "apiServerLbIp": {
+                                    "default": "10.0.0.2",
+                                    "description": "IP address for API server internal load balancer.",
+                                    "format": "ipv4",
+                                    "title": "API Server IP address",
+                                    "type": "string"
                                 }
                             },
                             "title": "Control plane",
@@ -398,6 +405,44 @@
                     "default": "PLACEHOLDER",
                     "title": "Subscription ID",
                     "type": "string"
+                },
+                "network": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "peerings": {
+                            "default": [],
+                            "description": "Specifying VNets (their resource groups and names) to which the peering is established.",
+                            "items": {
+                                "additionalProperties": false,
+                                "properties": {
+                                    "resourceGroup": {
+                                        "description": "Resource group for the remote VNet to which the peering is established.",
+                                        "pattern": "^[-\\w\\._\\(\\)]+$",
+                                        "minLength":  1,
+                                        "maxLength": 90,
+                                        "title": "Resource group name",
+                                        "type": "string"
+                                    },
+                                    "remoteVnetName": {
+                                        "description": "Name of the remote VNet to which the peering is established.",
+                                        "pattern": "^[-\\w\\._]+$",
+                                        "minLength":  2,
+                                        "maxLength": 64,
+                                        "title": "VNet name",
+                                        "type": "string"
+                                    }
+                                },
+                                "title": "VNet peering",
+                                "type": "object",
+                                "uniqueItems": true
+                            },
+                            "title": "VNet peerings",
+                            "type": "array"
+                        }
+                    },
+                    "description": "Azure VNet peering and other Azure-specific network settings.",
+                    "title": "Azure network settings",
+                    "type": "object"
                 }
             },
             "title": "Azure settings",

--- a/helm/cluster-azure/values.schema.json
+++ b/helm/cluster-azure/values.schema.json
@@ -37,7 +37,7 @@
                             "properties": {
                                 "apiServerLbIp": {
                                     "default": "10.0.0.2",
-                                    "description": "IP address for API server internal load balancer.",
+                                    "description": "IPv4 address of the internal API server load balancer.",
                                     "format": "ipv4",
                                     "title": "API Server IP address",
                                     "type": "string"

--- a/helm/cluster-azure/values.schema.json
+++ b/helm/cluster-azure/values.schema.json
@@ -257,15 +257,6 @@
                     },
                     "title": "Network configuration",
                     "type": "object"
-                },
-                "privateDNSZoneName": {
-                    "description": "In practice this is the base domain of the cluster.",
-                    "examples": [
-                        "my-org.example.com"
-                    ],
-                    "format": "hostname",
-                    "title": "Private DNS zone name",
-                    "type": "string"
                 }
             },
             "title": "Internal settings",

--- a/helm/cluster-azure/values.schema.json
+++ b/helm/cluster-azure/values.schema.json
@@ -59,6 +59,7 @@
                         },
                         "mode": {
                             "default": "public",
+                            "description": "Specifying if the cluster resources are publicly accessible or not.",
                             "enum": [
                                 "public",
                                 "private"
@@ -239,6 +240,15 @@
                 "kubernetesVersion": {
                     "default": "1.24.11",
                     "title": "Kubernetes version",
+                    "type": "string"
+                },
+                "privateDNSZoneName": {
+                    "description": "In practice this is the base domain of the cluster.",
+                    "examples": [
+                        "my-org.example.com"
+                    ],
+                    "format": "hostname",
+                    "title": "Private DNS zone name",
                     "type": "string"
                 }
             },

--- a/helm/cluster-azure/values.schema.json
+++ b/helm/cluster-azure/values.schema.json
@@ -35,16 +35,16 @@
                     "properties": {
                         "controlPlane": {
                             "properties": {
-                                "cidr": {
-                                    "default": "10.0.0.0/20",
-                                    "title": "Subnet",
-                                    "type": "string"
-                                },
                                 "apiServerLbIp": {
                                     "default": "10.0.0.2",
                                     "description": "IP address for API server internal load balancer.",
                                     "format": "ipv4",
                                     "title": "API Server IP address",
+                                    "type": "string"
+                                },
+                                "cidr": {
+                                    "default": "10.0.0.0/20",
+                                    "title": "Subnet",
                                     "type": "string"
                                 }
                             },
@@ -242,6 +242,29 @@
                     "title": "Kubernetes version",
                     "type": "string"
                 },
+                "network": {
+                    "description": "Internal network configuration that is susceptible to more frequent change",
+                    "properties": {
+                        "vpn": {
+                            "description": "Internal VPN configuration that is susceptible to more frequent change",
+                            "properties": {
+                                "gatewayMode": {
+                                    "default": "remote",
+                                    "enum": [
+                                        "local",
+                                        "remote"
+                                    ],
+                                    "title": "VPN gateway mode",
+                                    "type": "string"
+                                }
+                            },
+                            "title": "VPN configuration",
+                            "type": "object"
+                        }
+                    },
+                    "title": "Network configuration",
+                    "type": "object"
+                },
                 "privateDNSZoneName": {
                     "description": "In practice this is the base domain of the cluster.",
                     "examples": [
@@ -411,13 +434,9 @@
                     "title": "Location",
                     "type": "string"
                 },
-                "subscriptionId": {
-                    "default": "PLACEHOLDER",
-                    "title": "Subscription ID",
-                    "type": "string"
-                },
                 "network": {
                     "additionalProperties": false,
+                    "description": "Azure VNet peering and other Azure-specific network settings.",
                     "properties": {
                         "peerings": {
                             "default": [],
@@ -425,20 +444,20 @@
                             "items": {
                                 "additionalProperties": false,
                                 "properties": {
-                                    "resourceGroup": {
-                                        "description": "Resource group for the remote VNet to which the peering is established.",
-                                        "pattern": "^[-\\w\\._\\(\\)]+$",
-                                        "minLength":  1,
-                                        "maxLength": 90,
-                                        "title": "Resource group name",
-                                        "type": "string"
-                                    },
                                     "remoteVnetName": {
                                         "description": "Name of the remote VNet to which the peering is established.",
-                                        "pattern": "^[-\\w\\._]+$",
-                                        "minLength":  2,
                                         "maxLength": 64,
+                                        "minLength": 2,
+                                        "pattern": "^[-\\w\\._]+$",
                                         "title": "VNet name",
+                                        "type": "string"
+                                    },
+                                    "resourceGroup": {
+                                        "description": "Resource group for the remote VNet to which the peering is established.",
+                                        "maxLength": 90,
+                                        "minLength": 1,
+                                        "pattern": "^[-\\w\\._\\(\\)]+$",
+                                        "title": "Resource group name",
                                         "type": "string"
                                     }
                                 },
@@ -450,9 +469,13 @@
                             "type": "array"
                         }
                     },
-                    "description": "Azure VNet peering and other Azure-specific network settings.",
                     "title": "Azure network settings",
                     "type": "object"
+                },
+                "subscriptionId": {
+                    "default": "PLACEHOLDER",
+                    "title": "Subscription ID",
+                    "type": "string"
                 }
             },
             "title": "Azure settings",

--- a/helm/cluster-azure/values.schema.json
+++ b/helm/cluster-azure/values.schema.json
@@ -35,13 +35,6 @@
                     "properties": {
                         "controlPlane": {
                             "properties": {
-                                "apiServerLbIp": {
-                                    "default": "10.0.0.2",
-                                    "description": "IPv4 address of the internal API server load balancer.",
-                                    "format": "ipv4",
-                                    "title": "API Server IP address",
-                                    "type": "string"
-                                },
                                 "cidr": {
                                     "default": "10.0.0.0/20",
                                     "title": "Subnet",

--- a/helm/cluster-azure/values.yaml
+++ b/helm/cluster-azure/values.yaml
@@ -5,6 +5,7 @@ connectivity:
     instanceType: Standard_D2s_v5
   network:
     controlPlane:
+      apiServerLbIp: 10.0.0.2
       cidr: 10.0.0.0/20
     hostCidr: 10.0.0.0/16
     mode: public
@@ -54,4 +55,6 @@ providerSpecific:
     name: cluster-identity
     namespace: org-giantswarm
   location: westeurope
+  network:
+    peerings: []
   subscriptionId: PLACEHOLDER

--- a/helm/cluster-azure/values.yaml
+++ b/helm/cluster-azure/values.yaml
@@ -40,6 +40,9 @@ internal:
     name: ""
     version: 3374.2.4
   kubernetesVersion: 1.24.11
+  network:
+    vpn:
+      gatewayMode: remote
 metadata:
   servicePriority: highest
 nodePools:

--- a/helm/cluster-azure/values.yaml
+++ b/helm/cluster-azure/values.yaml
@@ -5,7 +5,6 @@ connectivity:
     instanceType: Standard_D2s_v5
   network:
     controlPlane:
-      apiServerLbIp: 10.0.0.2
       cidr: 10.0.0.0/20
     hostCidr: 10.0.0.0/16
     mode: public


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/2012

This pull requests adds support for private clusters. Considering that this is still initial support (and we hove more work to make this a nice experience), public clusters are still the default.

What's in the box:
- API server accessible via internal load balancer (inbound traffic).
  - Outbound traffic from control plane nodes goes via outbound load balancer.
  - Outbound traffic from worker nodes goes via NAT gateway.
- Enables creation of peering between MC and WC VNets (which is required for the private clusters to work).
- Private clusters are accessible only via VPN in the MC (MC-WC VNet peering is configured with gateway transit enabled).
- Private DNS zone name can (and should) be set for private clusters.
- Schema updates.

**Note**: This PR requires new CAPZ app alpha release ([here](https://github.com/giantswarm/cluster-api-provider-azure-app/pull/100)), which is currently waiting on a bugfix to be merged ([here](https://github.com/giantswarm/cluster-api-provider-azure-app/pull/98)).