### PR TITLE
Add a placeholder set of cluster-catalog values

### DIFF
--- a/.github/workflows/compare_rendering.yaml
+++ b/.github/workflows/compare_rendering.yaml
@@ -79,7 +79,7 @@ jobs:
           # TODO split files by "API"_"KIND"_"NAMESPACE|clusterwide"_"NAME"
           helm repo add cluster-catalog https://giantswarm.github.io/cluster-catalog/
           helm dependency build helm/cluster-azure
-          helm template -n org-multi-project -f helm/cluster-azure/ci/ci.yaml -f ${{ matrix.values }} helm/cluster-azure > /tmp/${{ matrix.values }}/render-new.yaml
+          helm template -n org-multi-project -f helm/cluster-azure/ci/ci-values.yaml -f ${{ matrix.values }} helm/cluster-azure > /tmp/${{ matrix.values }}/render-new.yaml
       - uses: actions/checkout@v3
         with:
           ref: 'main'
@@ -88,7 +88,7 @@ jobs:
         run: |
           # TODO split files by "API"_"KIND"_"NAMESPACE|clusterwide"_"NAME"
           helm dependency build old/helm/cluster-azure
-          helm template -n org-multi-project -f helm/cluster-azure/ci/ci.yaml -f ${{ matrix.values }} old/helm/cluster-azure > /tmp/${{ matrix.values }}/render-old.yaml
+          helm template -n org-multi-project -f helm/cluster-azure/ci/ci-values.yaml -f ${{ matrix.values }} old/helm/cluster-azure > /tmp/${{ matrix.values }}/render-old.yaml
       - name: get the diffs
         uses: mathiasvr/command-output@v1
         id: diff

--- a/.github/workflows/compare_rendering.yaml
+++ b/.github/workflows/compare_rendering.yaml
@@ -79,7 +79,7 @@ jobs:
           # TODO split files by "API"_"KIND"_"NAMESPACE|clusterwide"_"NAME"
           helm repo add cluster-catalog https://giantswarm.github.io/cluster-catalog/
           helm dependency build helm/cluster-azure
-          helm template -n org-multi-project -f helm/cluster-azure/ci/cluster-catalog-values.yaml -f ${{ matrix.values }} helm/cluster-azure > /tmp/${{ matrix.values }}/render-new.yaml
+          helm template -n org-multi-project -f helm/cluster-azure/ci/ci.yaml -f ${{ matrix.values }} helm/cluster-azure > /tmp/${{ matrix.values }}/render-new.yaml
       - uses: actions/checkout@v3
         with:
           ref: 'main'
@@ -88,7 +88,7 @@ jobs:
         run: |
           # TODO split files by "API"_"KIND"_"NAMESPACE|clusterwide"_"NAME"
           helm dependency build old/helm/cluster-azure
-          helm template -n org-multi-project -f helm/cluster-azure/ci/cluster-catalog-values.yaml -f ${{ matrix.values }} old/helm/cluster-azure > /tmp/${{ matrix.values }}/render-old.yaml
+          helm template -n org-multi-project -f helm/cluster-azure/ci/ci.yaml -f ${{ matrix.values }} old/helm/cluster-azure > /tmp/${{ matrix.values }}/render-old.yaml
       - name: get the diffs
         uses: mathiasvr/command-output@v1
         id: diff

--- a/.github/workflows/compare_rendering.yaml
+++ b/.github/workflows/compare_rendering.yaml
@@ -79,7 +79,7 @@ jobs:
           # TODO split files by "API"_"KIND"_"NAMESPACE|clusterwide"_"NAME"
           helm repo add cluster-catalog https://giantswarm.github.io/cluster-catalog/
           helm dependency build helm/cluster-azure
-          helm template -n org-multi-project -f ${{ matrix.values }} helm/cluster-azure > /tmp/${{ matrix.values }}/render-new.yaml
+          helm template -n org-multi-project -f helm/cluster-azure/ci/cluster-catalog-values.yaml -f ${{ matrix.values }} helm/cluster-azure > /tmp/${{ matrix.values }}/render-new.yaml
       - uses: actions/checkout@v3
         with:
           ref: 'main'
@@ -88,7 +88,7 @@ jobs:
         run: |
           # TODO split files by "API"_"KIND"_"NAMESPACE|clusterwide"_"NAME"
           helm dependency build old/helm/cluster-azure
-          helm template -n org-multi-project -f ${{ matrix.values }} old/helm/cluster-azure > /tmp/${{ matrix.values }}/render-old.yaml
+          helm template -n org-multi-project -f helm/cluster-azure/ci/cluster-catalog-values.yaml -f ${{ matrix.values }} old/helm/cluster-azure > /tmp/${{ matrix.values }}/render-old.yaml
       - name: get the diffs
         uses: mathiasvr/command-output@v1
         id: diff

--- a/helm/cluster-azure/ci/ci-values.yaml
+++ b/helm/cluster-azure/ci/ci-values.yaml
@@ -1,3 +1,7 @@
+baseDomain: azuretest.gigantic.io
+managementCluster: MCCLUSTER
+provider: capz
+
 metadata:
   organization: test
   servicePriority: lowest

--- a/helm/cluster-azure/ci/cluster-catalog-values.yaml
+++ b/helm/cluster-azure/ci/cluster-catalog-values.yaml
@@ -1,0 +1,3 @@
+baseDomain: azuretest.gigantic.io
+managementCluster: MCCLUSTER
+provider: capz

--- a/helm/cluster-azure/ci/cluster-catalog-values.yaml
+++ b/helm/cluster-azure/ci/cluster-catalog-values.yaml
@@ -1,3 +1,0 @@
-baseDomain: azuretest.gigantic.io
-managementCluster: MCCLUSTER
-provider: capz


### PR DESCRIPTION
these are pushed by app-operator on real clusters, we need them to render the manifest properly

Follow up to https://github.com/giantswarm/cluster-azure/pull/94#issuecomment-1486647737 @nprokopic 


### Please check if PR meets these requirements

- [ ] Results of the diffs have been examined and no unintended changes are being introduced.

### Helper

* to disable the GH Action generating manifests diffs for installations, between target and source branches, comment the `/no_diffs_printing` on the PR.
