### PR TITLE
Updated PR template with test trigger for new e2e test suites

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,3 +6,11 @@
 ### Helper
 
 * to disable the GH Action generating manifests diffs for installations, between target and source branches, comment the `/no_diffs_printing` on the PR.
+
+### Trigger e2e tests
+
+<!--
+If for some reason you want to skip the e2e tests, remove the following lines.
+-->
+
+/run cluster-test-suites


### PR DESCRIPTION
### Please check if PR meets these requirements

- [ ] Results of the diffs have been examined and no unintended changes are being introduced.

### Helper

* to disable the GH Action generating manifests diffs for installations, between target and source branches, comment the `/no_diffs_printing` on the PR.

### Trigger e2e tests

<!--
If for some reason you want to skip the e2e tests, remove the following lines.
-->

/run cluster-test-suites