### PR TITLE
Skip kube-proxy phase to be replaced with cilium

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add support for private clusters.
 
+### Changed
+
+- Skip `kube-proxy` during kubeadm init/join to replace with cilium-proxy
+  - This change requies default-apps >= 0.0.14
+
 ## [0.0.16] - 2023-03-27
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Skip `kube-proxy` during kubeadm init/join to replace with cilium-proxy
+- :boom: Breaking - Skip `kube-proxy` during kubeadm init/join to replace with cilium-proxy
   - This change requies default-apps >= 0.0.14
 
 ## [0.0.16] - 2023-03-27

--- a/examples/cluster-default/02_apps.yaml
+++ b/examples/cluster-default/02_apps.yaml
@@ -16,7 +16,7 @@ spec:
     configMap:
       name: cluster01-user-values
       namespace: org-multi-project
-  version: 0.0.15
+  version: 0.0.17
 ---
 apiVersion: application.giantswarm.io/v1alpha1
 kind: App
@@ -37,4 +37,4 @@ spec:
     configMap:
       name: cluster01-default-apps-user-values
       namespace: org-multi-project
-  version: v0.0.12
+  version: v0.0.14

--- a/helm/cluster-azure/templates/_kcp.tpl
+++ b/helm/cluster-azure/templates/_kcp.tpl
@@ -197,6 +197,7 @@ spec:
     initConfiguration:
       skipPhases:
       - addon/coredns
+      - addon/kube-proxy
       nodeRegistration:
         kubeletExtraArgs:
           azure-container-registry-config: /etc/kubernetes/azure.json


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/25360 

### Please check if PR meets these requirements

- [x] Results of the diffs have been examined and no unintended changes are being introduced.

### Helper

* to disable the GH Action generating manifests diffs for installations, between target and source branches, comment the `/no_diffs_printing` on the PR.

### Trigger e2e tests

<!--
If for some reason you want to skip the e2e tests, remove the following lines.
-->

/run cluster-test-suites
