### PR TITLE
replace pause image for containerd

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Rename JSON schema makefile commands to `normalize-schema`, `validate-schema`, `generate-values`.
+- Add replacement of pause image for kubelet and containerd to use `quay.io/giantswarm/pause`
 
 ## [0.0.17] - 2023-04-04
 

--- a/helm/cluster-azure/templates/_helpers.tpl
+++ b/helm/cluster-azure/templates/_helpers.tpl
@@ -186,6 +186,8 @@ See more details here https://github.com/giantswarm/roadmap/issues/2223.
 # Won't be needed anymore once https://github.com/giantswarm/capi-image-builder/pull/81 has been released and new images build out of it
 {{- define "override-pause-image-with-quay" -}}
 - sed -i -e 's/registry.k8s.io\/pause/quay.io\/giantswarm\/pause/' /etc/sysconfig/kubelet
+- sed -i -e 's/registry.k8s.io\/pause/quay.io\/giantswarm\/pause/' /etc/containerd/config.toml
+- systemctl restart containerd
 {{- end -}}
 
 {{/*


### PR DESCRIPTION
- Also replace pause image for containerd
- Update changelog


### Please check if PR meets these requirements

- [ ] Results of the diffs have been examined and no unintended changes are being introduced.

### Helper

* to disable the GH Action generating manifests diffs for installations, between target and source branches, comment the `/no_diffs_printing` on the PR.

### Trigger e2e tests

<!--
If for some reason you want to skip the e2e tests, remove the following lines.
-->

/run cluster-test-suites
