### PR TITLE
revert kube proxy replacement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Rename JSON schema makefile commands to `normalize-schema`, `validate-schema`, `generate-values`.
 - Add replacement of pause image for kubelet and containerd to use `quay.io/giantswarm/pause`
+- Revert `cilium kube-proxy` replacement - do not skip kube-proxy
 
 ## [0.0.17] - 2023-04-04
 

--- a/helm/cluster-azure/templates/_kcp.tpl
+++ b/helm/cluster-azure/templates/_kcp.tpl
@@ -197,7 +197,6 @@ spec:
     initConfiguration:
       skipPhases:
       - addon/coredns
-      - addon/kube-proxy
       nodeRegistration:
         kubeletExtraArgs:
           azure-container-registry-config: /etc/kubernetes/azure.json


### PR DESCRIPTION
- do not skip kube-proxy when creating cluster
- Update changelog


### Please check if PR meets these requirements

- [x] Results of the diffs have been examined and no unintended changes are being introduced.

### Helper

* to disable the GH Action generating manifests diffs for installations, between target and source branches, comment the `/no_diffs_printing` on the PR.

### Trigger e2e tests

<!--
If for some reason you want to skip the e2e tests, remove the following lines.
-->

/run cluster-test-suites
