### PR TITLE
Simplify the subnet naming templates

### DIFF
--- a/helm/cluster-azure/templates/_azure_cluster.tpl
+++ b/helm/cluster-azure/templates/_azure_cluster.tpl
@@ -15,7 +15,7 @@ spec:
   location: {{ .Values.providerSpecific.location }}
   networkSpec:
     subnets:
-      - name: {{ if ( include "network.subnets.controlPlane.name" $ ) }}{{ include "network.subnets.controlPlane.name" $ }}{{ else }}control-plane-subnet{{ end }}
+      - name: {{ include "network.subnets.controlPlane.name" $ }}
         role: control-plane
         cidrBlocks:
         - {{ .Values.connectivity.network.controlPlane.cidr }}
@@ -44,9 +44,9 @@ spec:
              source: "*"
              sourcePorts: "*"
         {{- end }}
-      - name: {{ if ( include "network.subnets.nodes.name" $ ) }}{{ include "network.subnets.nodes.name" $ }}{{ else }}node-subnet{{ end }}
+      - name: {{ include "network.subnets.nodes.name" $ }}
         natGateway:
-          name: {{ if ( include "network.subnets.nodes.natGatewayName" $ ) }}{{ include "network.subnets.nodes.natGatewayName" $ }}{{ else }}node-natgateway{{ end }}
+          name: {{ include "network.subnets.nodes.natGatewayName" $ }}
         role: node
         cidrBlocks:
         - {{ .Values.connectivity.network.workers.cidr }}

--- a/helm/cluster-azure/templates/_bastion.tpl
+++ b/helm/cluster-azure/templates/_bastion.tpl
@@ -21,17 +21,9 @@ sshPublicKey: {{ include "fake-rsa-ssh-key" $ | b64enc }}
 {{- if (hasKey $.spec "subnetName") }}
 subnetName: {{ $.spec.subnetName }}
 {{- else if (eq .Values.connectivity.network.mode "private") }}
-  {{- if ( include "network.subnets.controlPlane.name" $ ) }}
-subnetName: {{ include "network.subnets.controlPlane.name" $ }}
-  {{- else }}
-subnetName: "node-subnet"
-  {{- end }}
+subnetName: {{ include "network.subnets.nodes.name" $ }}
 {{- else }}
-  {{- if ( include "network.subnets.controlPlane.name" $ ) }}
 subnetName: {{ include "network.subnets.controlPlane.name" $ }}
-  {{- else }}
-subnetName: "control-plane-subnet"
-  {{- end }}
 {{- end }}
 allocatePublicIP: {{ ternary false true (eq .Values.connectivity.network.mode "private" ) }}
 vmSize: {{ .spec.instanceType }}

--- a/helm/cluster-azure/templates/_helpers.tpl
+++ b/helm/cluster-azure/templates/_helpers.tpl
@@ -255,18 +255,24 @@ It expects one argument which is the control plane subnet network range in forma
 {{- define "network.subnets.controlPlane.name" -}}
 {{- if hasKey $.Values.internal.network.subnets "controlPlaneSubnetName" -}}
 {{ $.Values.internal.network.subnets.controlPlaneSubnetName }}
+{{- else -}}
+control-plane-subnet
 {{- end -}}
 {{- end -}}
 
 {{- define "network.subnets.nodes.name" -}}
 {{- if hasKey $.Values.internal.network.subnets "nodesSubnetName" -}}
 {{ $.Values.internal.network.subnets.nodesSubnetName }}
+{{- else -}}
+node-subnet
 {{- end -}}
 {{- end -}}
 
 {{- define "network.subnets.nodes.natGatewayName" -}}
 {{- if hasKey $.Values.internal.network.subnets "nodeSubnetNatGatewayName" -}}
 {{ $.Values.internal.network.subnets.nodeSubnetNatGatewayName }}
+{{- else -}}
+node-natgateway
 {{- end -}}
 {{- end -}}
 


### PR DESCRIPTION

### Please check if PR meets these requirements

- [ ] Results of the diffs have been examined and no unintended changes are being introduced.

### Helper

* to disable the GH Action generating manifests diffs for installations, between target and source branches, comment the `/no_diffs_printing` on the PR.

### Trigger e2e tests

<!--
If for some reason you want to skip the e2e tests, remove the following lines.
-->

/run cluster-test-suites
