### PR TITLE
remove kube proxy phase with private cluster support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- :boom: Breaking - Skip `kube-proxy` during kubeadm init/join to replace with cilium-proxy
+  - This change requies default-apps >= 0.0.17
+
 ## [0.0.20] - 2023-04-26
 
 ### Changed

--- a/helm/cluster-azure/templates/_azure_cluster.tpl
+++ b/helm/cluster-azure/templates/_azure_cluster.tpl
@@ -68,6 +68,17 @@ spec:
       frontendIPs:
       - name: {{ include "resource.default.name" $ }}-api-internal-lb-frontend-ip
         privateIP: "{{- include "controlPlane.apiServerLbIp" .Values.connectivity.network.controlPlane.cidr | trim -}}"
+      privateLinks:
+      - name: {{ include "resource.default.name" $ }}-api-privatelink
+        natIpConfigurations:
+        - allocationMethod: Dynamic
+          subnet: {{ include "network.subnets.nodes.name" $ }}
+        lbFrontendIPConfigNames:
+        - {{ include "resource.default.name" $ }}-api-internal-lb-frontend-ip
+        allowedSubscriptions:
+        - {{ .Values.providerSpecific.subscriptionId }}
+        autoApprovedSubscriptions:
+        - {{ .Values.providerSpecific.subscriptionId }}
     controlPlaneOutboundLB:
       frontendIPsCount: 1
     {{end}}

--- a/helm/cluster-azure/templates/_kcp.tpl
+++ b/helm/cluster-azure/templates/_kcp.tpl
@@ -200,6 +200,7 @@ spec:
     initConfiguration:
       skipPhases:
       - addon/coredns
+      - addon/kube-proxy
       nodeRegistration:
         kubeletExtraArgs:
           azure-container-registry-config: /etc/kubernetes/azure.json


### PR DESCRIPTION
- Remove kube-proxy phase
- Add code for privatelink

This is just a placeholder PR that includes both

* https://github.com/giantswarm/cluster-azure/pull/121
* https://github.com/giantswarm/cluster-azure/pull/122/

**NOT TO BE MERGED**

### Please check if PR meets these requirements

- [ ] Results of the diffs have been examined and no unintended changes are being introduced.

### Helper

* to disable the GH Action generating manifests diffs for installations, between target and source branches, comment the `/no_diffs_printing` on the PR.

### Trigger e2e tests

<!--
If for some reason you want to skip the e2e tests, remove the following lines.
-->

/run cluster-test-suites
