### PR TITLE
Upgrade flatcar image and kubernetes version to latest stable 3510.2.1 and 1.24.13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Upgrade Flatcar image to [3510.2.1](https://www.flatcar.org/releases#release-3510.2.1)
+- Upgrade K8S version to `1.24.13`
+
 ### Added
 
 - Add full configuration values documentation.

--- a/helm/cluster-azure/README.md
+++ b/helm/cluster-azure/README.md
@@ -61,8 +61,8 @@ Configuration of an Azure cluster using Cluster API
 | `Cluster configuration.internal.image` | **Node Image**|**Type:** `object`<br/>|
 | `Cluster configuration.internal.image.gallery` | **Gallery** - Name of the community gallery hosting the image|**Type:** `string`<br/>**Default:** `"gsCapzFlatcar-41c2d140-ac44-4d8b-b7e1-7b2f1ddbe4d0"`|
 | `Cluster configuration.internal.image.name` | **Image Definition** - Name of the image definition in the Gallery|**Type:** `string`<br/>**Default:** `""`|
-| `Cluster configuration.internal.image.version` | **Image version**|**Type:** `string`<br/>**Default:** `"3374.2.4"`|
-| `Cluster configuration.internal.kubernetesVersion` | **Kubernetes version**|**Type:** `string`<br/>**Default:** `"1.24.11"`|
+| `Cluster configuration.internal.image.version` | **Image version**|**Type:** `string`<br/>**Default:** `"3510.2.1"`|
+| `Cluster configuration.internal.kubernetesVersion` | **Kubernetes version**|**Type:** `string`<br/>**Default:** `"1.24.13"`|
 | `Cluster configuration.internal.network` | **Network configuration** - Internal network configuration that is susceptible to more frequent change|**Type:** `object`<br/>|
 | `Cluster configuration.internal.network.subnets` | **VNet spec** - Customize subnets configuration|**Type:** `object`<br/>**Default:** `{}`|
 | `Cluster configuration.internal.network.subnets.controlPlaneSubnetName` | **ControlPlane subnet name** - Name of the control plane subnet.|**Type:** `string`<br/>**Value pattern:** `^[-\w\._]+$`<br/>|

--- a/helm/cluster-azure/values.schema.json
+++ b/helm/cluster-azure/values.schema.json
@@ -239,7 +239,7 @@
                             "type": "string"
                         },
                         "version": {
-                            "default": "3374.2.4",
+                            "default": "3510.2.1",
                             "title": "Image version",
                             "type": "string"
                         }
@@ -248,7 +248,7 @@
                     "type": "object"
                 },
                 "kubernetesVersion": {
-                    "default": "1.24.11",
+                    "default": "1.24.13",
                     "title": "Kubernetes version",
                     "type": "string"
                 },

--- a/helm/cluster-azure/values.yaml
+++ b/helm/cluster-azure/values.yaml
@@ -41,8 +41,8 @@ internal:
   image:
     gallery: gsCapzFlatcar-41c2d140-ac44-4d8b-b7e1-7b2f1ddbe4d0
     name: ""
-    version: 3374.2.4
-  kubernetesVersion: 1.24.11
+    version: 3510.2.1
+  kubernetesVersion: 1.24.13
   network:
     subnets: {}
     vnet: {}


### PR DESCRIPTION

### Please check if PR meets these requirements

- [ ] Results of the diffs have been examined and no unintended changes are being introduced.

### Helper

* to disable the GH Action generating manifests diffs for installations, between target and source branches, comment the `/no_diffs_printing` on the PR.

### Trigger e2e tests

<!--
If for some reason you want to skip the e2e tests, remove the following lines.
-->

/run cluster-test-suites
