### PR TITLE
Set minimum / exclusiveMinimum constraint on integer properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Add value schema constraints to all numeric types, using `exclusiveMinimum` of zero.
+
 ## [0.0.22] - 2023-05-17
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Add value schema constraints to all numeric types, using `exclusiveMinimum` of zero.
+- Add value schema constraints to all numeric types, using `exclusiveMinimum` or `minimum` of zero.
 
 ## [0.0.22] - 2023-05-17
 

--- a/helm/cluster-azure/values.schema.json
+++ b/helm/cluster-azure/values.schema.json
@@ -113,7 +113,8 @@
                 "etcdVolumeSizeGB": {
                     "type": "integer",
                     "title": "Etcd volume size (GB)",
-                    "default": 10
+                    "default": 10,
+                    "exclusiveMinimum": 0
                 },
                 "instanceType": {
                     "type": "string",
@@ -155,12 +156,14 @@
                 "replicas": {
                     "type": "integer",
                     "title": "Number of nodes",
-                    "default": 3
+                    "default": 3,
+                    "exclusiveMinimum": 0
                 },
                 "rootVolumeSizeGB": {
                     "type": "integer",
                     "title": "Root volume size (GB)",
-                    "default": 50
+                    "default": 50,
+                    "exclusiveMinimum": 0
                 }
             }
         },
@@ -446,11 +449,13 @@
                     },
                     "replicas": {
                         "type": "integer",
-                        "title": "Number of nodes"
+                        "title": "Number of nodes",
+                        "exclusiveMinimum": 0
                     },
                     "rootVolumeSizeGB": {
                         "type": "integer",
-                        "title": "Root volume size (GB)"
+                        "title": "Root volume size (GB)",
+                        "exclusiveMinimum": 0
                     }
                 }
             },

--- a/helm/cluster-azure/values.schema.json
+++ b/helm/cluster-azure/values.schema.json
@@ -450,7 +450,7 @@
                     "replicas": {
                         "type": "integer",
                         "title": "Number of nodes",
-                        "exclusiveMinimum": 0
+                        "minimum": 0
                     },
                     "rootVolumeSizeGB": {
                         "type": "integer",


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/2103

This PR adds constraints to all integer fields in the schema, to prevent users from setting a value of zero or less.

As an exception, for node pools, the number of nodes is allowed to be set to zero.