### PR TITLE
Remove CSIMigration flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Removed
+
+- Remove CSIMigration feature flag (enabled by default with k8s 1.23).
+
 ## [0.0.24] - 2023-06-07
 
 ### Changed

--- a/helm/cluster-azure/templates/_kcp.tpl
+++ b/helm/cluster-azure/templates/_kcp.tpl
@@ -156,7 +156,7 @@ spec:
           cloud-provider: external
           cluster-name: {{ include "resource.default.name" $ }}
           external-cloud-volume-plugin: azure
-          feature-gates: "CSIMigrationAzureDisk=true,TTLAfterFinished=true"
+          feature-gates: "TTLAfterFinished=true"
         extraVolumes:
           - hostPath: /etc/kubernetes/azure.json
             mountPath: /etc/kubernetes/azure.json
@@ -206,7 +206,6 @@ spec:
           azure-container-registry-config: /etc/kubernetes/azure.json
           cloud-config: /etc/kubernetes/azure.json
           cloud-provider: external
-          feature-gates: CSIMigrationAzureDisk=true
           eviction-soft: {{ .Values.internal.defaults.softEvictionThresholds }}
           eviction-soft-grace-period: {{ .Values.internal.defaults.softEvictionGracePeriod }}
           eviction-hard: {{ .Values.internal.defaults.hardEvictionThresholds }}
@@ -223,7 +222,6 @@ spec:
           azure-container-registry-config: /etc/kubernetes/azure.json
           cloud-config: /etc/kubernetes/azure.json
           cloud-provider: external
-          feature-gates: CSIMigrationAzureDisk=true
           eviction-soft: {{ .Values.internal.defaults.softEvictionThresholds }}
           eviction-soft-grace-period: {{ .Values.internal.defaults.softEvictionGracePeriod }}
           eviction-hard: {{ .Values.internal.defaults.hardEvictionThresholds }}

--- a/helm/cluster-azure/templates/_machine_helpers.tpl
+++ b/helm/cluster-azure/templates/_machine_helpers.tpl
@@ -39,7 +39,6 @@ joinConfiguration:
       azure-container-registry-config: /etc/kubernetes/azure.json
       cloud-config: /etc/kubernetes/azure.json
       cloud-provider: external
-      feature-gates: CSIMigrationAzureDisk=true
       eviction-soft: {{ .Values.internal.defaults.softEvictionThresholds }}
       eviction-soft-grace-period: {{ .Values.internal.defaults.softEvictionGracePeriod }}
       eviction-hard: {{ .Values.internal.defaults.hardEvictionThresholds }}


### PR DESCRIPTION
CSIMigrationAzureDisk is enabled by default since 1.23

Issue: https://github.com/giantswarm/roadmap/issues/2536
Reference: https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates-removed/

### Please check if PR meets these requirements

- [ ] Results of the diffs have been examined and no unintended changes are being introduced.

### Helper

* to disable the GH Action generating manifests diffs for installations, between target and source branches, comment the `/no_diffs_printing` on the PR.

### Trigger e2e tests

<!--
If for some reason you want to skip the e2e tests, remove the following lines.
-->

/run cluster-test-suites