### PR TITLE
Make `subscriptionId` required, add constraints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Value `.providerSpecific.subscriptionId` marked as required, constrained to UUID format.
+
 ### Removed
 
 - Remove CSIMigration feature flag (enabled by default with k8s 1.23).

--- a/helm/cluster-azure/ci/ci-values.yaml
+++ b/helm/cluster-azure/ci/ci-values.yaml
@@ -3,7 +3,7 @@ managementCluster: MCCLUSTER
 provider: capz
 
 providerSpecific:
-  subscriptionId: PLACEHOLDER
+  subscriptionId: 12345678-abcd-1234-abcd-1234567abcde
 
 metadata:
   organization: test

--- a/helm/cluster-azure/ci/test-mc-custom-vnet-values.yaml
+++ b/helm/cluster-azure/ci/test-mc-custom-vnet-values.yaml
@@ -5,7 +5,7 @@ metadata:
 
 providerSpecific:
   location: "westeurope"
-  subscriptionId: "PLACEHOLDER_SUBSCRIPTION_ID"
+  subscriptionId: 12345678-abcd-1234-abcd-1234567abcde
 
 connectivity:
   network:

--- a/helm/cluster-azure/ci/test-mc-values.yaml
+++ b/helm/cluster-azure/ci/test-mc-values.yaml
@@ -7,7 +7,7 @@ metadata:
 
 providerSpecific:
   location: "westeurope"
-  subscriptionId: "PLACEHOLDER_SUBSCRIPTION_ID"
+  subscriptionId: 12345678-abcd-1234-abcd-1234567abcde
 
 connectivity:
   network:

--- a/helm/cluster-azure/ci/test-wc-minimal-values.yaml
+++ b/helm/cluster-azure/ci/test-wc-minimal-values.yaml
@@ -5,4 +5,4 @@ metadata:
 
 providerSpecific:
   location: "westeurope"
-  subscriptionId: "PLACEHOLDER_SUBSCRIPTION_ID"
+  subscriptionId: 12345678-abcd-1234-abcd-1234567abcde

--- a/helm/cluster-azure/ci/test-wc-private-values.yaml
+++ b/helm/cluster-azure/ci/test-wc-private-values.yaml
@@ -5,7 +5,7 @@ metadata:
 
 providerSpecific:
   location: "westeurope"
-  subscriptionId: "PLACEHOLDER_SUBSCRIPTION_ID"
+  subscriptionId: 12345678-abcd-1234-abcd-1234567abcde
 
 connectivity:
   network:

--- a/helm/cluster-azure/ci/test-wc-restricted-access-values.yaml
+++ b/helm/cluster-azure/ci/test-wc-restricted-access-values.yaml
@@ -10,7 +10,7 @@ connectivity:
 
 providerSpecific:
   location: "westeurope"
-  subscriptionId: "PLACEHOLDER_SUBSCRIPTION_ID"
+  subscriptionId: 12345678-abcd-1234-abcd-1234567abcde
 
 internal:
   identity:

--- a/helm/cluster-azure/ci/test-wc-values.yaml
+++ b/helm/cluster-azure/ci/test-wc-values.yaml
@@ -7,7 +7,7 @@ metadata:
 
 providerSpecific:
   location: "westeurope"
-  subscriptionId: "PLACEHOLDER_SUBSCRIPTION_ID"
+  subscriptionId: 12345678-abcd-1234-abcd-1234567abcde
 
 connectivity:
   network:

--- a/helm/cluster-azure/values.schema.json
+++ b/helm/cluster-azure/values.schema.json
@@ -490,6 +490,9 @@
         "providerSpecific": {
             "type": "object",
             "title": "Azure settings",
+            "required": [
+                "subscriptionId"
+            ],
             "properties": {
                 "azureClusterIdentity": {
                     "type": "object",
@@ -553,7 +556,14 @@
                 },
                 "subscriptionId": {
                     "type": "string",
-                    "title": "Subscription ID"
+                    "title": "Subscription ID",
+                    "description": "ID of the Azure subscription this cluster will run in.",
+                    "examples": [
+                        "291bba3f-e0a5-47bc-a099-3bdcb2a50a05"
+                    ],
+                    "maxLength": 36,
+                    "minLength": 36,
+                    "pattern": "^[a-fA-F0-9][-a-fA-F0-9]+[a-fA-F0-9]$"
                 }
             }
         }


### PR DESCRIPTION
Clusters won't come up if users don't set a valid Azure subscription ID. Currently the subscription ID is not a required property, so this is an easy mistake to make.

This PR sets the subscription ID as required. It als adds constraints to help avoid input mistakes, or catch them early.

An alternative to setting the property as required would be to make sure it gets defaulted in the backend. In that case we would hide it in the web UI form.