### PR TITLE
Restrict `.providerSpecific.location` value to enum

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Restricted `.providerSpecific.location` value to a set of defined region names.
+
 ## [0.0.25] - 2023-06-14
 
 ### Changed

--- a/helm/cluster-azure/README.md
+++ b/helm/cluster-azure/README.md
@@ -26,7 +26,7 @@ Properties within the `.providerSpecific` top-level object
 | `providerSpecific.network.peerings[*]` | **VNet peering**|**Type:** `object`<br/>|
 | `providerSpecific.network.peerings[*].remoteVnetName` | **VNet name** - Name of the remote VNet to which the peering is established.|**Type:** `string`<br/>**Value pattern:** `^[-\w\._]+$`<br/>|
 | `providerSpecific.network.peerings[*].resourceGroup` | **Resource group name** - Resource group for the remote VNet to which the peering is established.|**Type:** `string`<br/>**Value pattern:** `^[-\w\._\(\)]+$`<br/>|
-| `providerSpecific.subscriptionId` | **Subscription ID**|**Type:** `string`<br/>|
+| `providerSpecific.subscriptionId` | **Subscription ID** - ID of the Azure subscription this cluster will run in.|**Type:** `string`<br/>**Example:** `"291bba3f-e0a5-47bc-a099-3bdcb2a50a05"`<br/>**Value pattern:** `^[a-fA-F0-9][-a-fA-F0-9]+[a-fA-F0-9]$`<br/>|
 
 ### Connectivity
 Properties within the `.connectivity` top-level object
@@ -102,6 +102,8 @@ Properties within the `.metadata` top-level object
 | **Property** | **Description** | **More Details** |
 | :----------- | :-------------- | :--------------- |
 | `metadata.description` | **Cluster description** - User-friendly description of the cluster's purpose.|**Type:** `string`<br/>|
+| `metadata.labels` | **Labels** - These labels are added to the Kubernetes resourses defining this cluster.|**Type:** `object`<br/>|
+| `metadata.labels.PATTERN` | **Label**|**Type:** `string`<br/>**Key pattern:**<br/>`PATTERN`=`^[a-zA-Z0-9\._-]+$`<br/>**Value pattern:** `^[a-zA-Z0-9\._-]+$`<br/>|
 | `metadata.name` | **Cluster name** - Unique identifier, cannot be changed after creation.|**Type:** `string`<br/>|
 | `metadata.organization` | **Organization**|**Type:** `string`<br/>|
 | `metadata.servicePriority` | **Service priority** - The relative importance of this cluster.|**Type:** `string`<br/>**Default:** `"highest"`|

--- a/helm/cluster-azure/values.schema.json
+++ b/helm/cluster-azure/values.schema.json
@@ -514,6 +514,14 @@
                 "location": {
                     "type": "string",
                     "title": "Location",
+                    "$comment": "Valid options from https://github.com/giantswarm/capi-image-builder/blob/v1.6.10/helm/capi-image-builder/values.yaml#L48-L52",
+                    "enum": [
+                        "eastus",
+                        "germanywestcentral",
+                        "northeurope",
+                        "westeurope",
+                        "westus2"
+                    ],
                     "default": "westeurope"
                 },
                 "network": {


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/2573

To avoid bad values (especially unsupported regions), this PR restricts the location value to a set of defined values, taken from https://github.com/giantswarm/capi-image-builder/blob/v1.6.10/helm/capi-image-builder/values.yaml#L48-L52

This also means that when the list in `capi-image-builder` gets changed, it should be changed here accordingly.

### Please check if PR meets these requirements

- [x] Results of the diffs have been examined and no unintended changes are being introduced.

### Helper

* to disable the GH Action generating manifests diffs for installations, between target and source branches, comment the `/no_diffs_printing` on the PR.

### Trigger e2e tests

/run cluster-test-suites
