### PR TITLE
Disallow additionalProperties on the .metadata.labels object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Disallow additional properties on the `.metadata.labels` object.
+
 ## [0.0.25] - 2023-06-14
 
 ### Changed

--- a/helm/cluster-azure/README.md
+++ b/helm/cluster-azure/README.md
@@ -102,6 +102,8 @@ Properties within the `.metadata` top-level object
 | **Property** | **Description** | **More Details** |
 | :----------- | :-------------- | :--------------- |
 | `metadata.description` | **Cluster description** - User-friendly description of the cluster's purpose.|**Type:** `string`<br/>|
+| `metadata.labels` | **Labels** - These labels are added to the Kubernetes resourses defining this cluster.|**Type:** `object`<br/>|
+| `metadata.labels.PATTERN` | **Label**|**Type:** `string`<br/>**Key pattern:**<br/>`PATTERN`=`^[a-zA-Z0-9/\._-]+$`<br/>**Value pattern:** `^[a-zA-Z0-9\._-]+$`<br/>|
 | `metadata.name` | **Cluster name** - Unique identifier, cannot be changed after creation.|**Type:** `string`<br/>|
 | `metadata.organization` | **Organization**|**Type:** `string`<br/>|
 | `metadata.servicePriority` | **Service priority** - The relative importance of this cluster.|**Type:** `string`<br/>**Default:** `"highest"`|

--- a/helm/cluster-azure/README.md
+++ b/helm/cluster-azure/README.md
@@ -26,7 +26,7 @@ Properties within the `.providerSpecific` top-level object
 | `providerSpecific.network.peerings[*]` | **VNet peering**|**Type:** `object`<br/>|
 | `providerSpecific.network.peerings[*].remoteVnetName` | **VNet name** - Name of the remote VNet to which the peering is established.|**Type:** `string`<br/>**Value pattern:** `^[-\w\._]+$`<br/>|
 | `providerSpecific.network.peerings[*].resourceGroup` | **Resource group name** - Resource group for the remote VNet to which the peering is established.|**Type:** `string`<br/>**Value pattern:** `^[-\w\._\(\)]+$`<br/>|
-| `providerSpecific.subscriptionId` | **Subscription ID**|**Type:** `string`<br/>|
+| `providerSpecific.subscriptionId` | **Subscription ID** - ID of the Azure subscription this cluster will run in.|**Type:** `string`<br/>**Example:** `"291bba3f-e0a5-47bc-a099-3bdcb2a50a05"`<br/>**Value pattern:** `^[a-fA-F0-9][-a-fA-F0-9]+[a-fA-F0-9]$`<br/>|
 
 ### Connectivity
 Properties within the `.connectivity` top-level object

--- a/helm/cluster-azure/ci/ci-values.yaml
+++ b/helm/cluster-azure/ci/ci-values.yaml
@@ -9,4 +9,4 @@ metadata:
   organization: test
   servicePriority: lowest
   labels:
-     test.io/testing: test-label
+    test.io/testing: test-label

--- a/helm/cluster-azure/ci/ci-values.yaml
+++ b/helm/cluster-azure/ci/ci-values.yaml
@@ -8,3 +8,5 @@ providerSpecific:
 metadata:
   organization: test
   servicePriority: lowest
+  labels:
+     test.io/testing: test-label

--- a/helm/cluster-azure/values.schema.json
+++ b/helm/cluster-azure/values.schema.json
@@ -356,6 +356,7 @@
                     "type": "object",
                     "title": "Labels",
                     "description": "These labels are added to the Kubernetes resourses defining this cluster.",
+                    "additionalProperties": false,
                     "patternProperties": {
                         "^[a-zA-Z0-9/\\._-]+$": {
                             "type": "string",

--- a/helm/cluster-azure/values.schema.json
+++ b/helm/cluster-azure/values.schema.json
@@ -357,7 +357,7 @@
                     "title": "Labels",
                     "description": "These labels are added to the Kubernetes resourses defining this cluster.",
                     "patternProperties": {
-                        "^[a-zA-Z0-9\\._-]+$": {
+                        "^[a-zA-Z0-9/\\._-]+$": {
                             "type": "string",
                             "title": "Label",
                             "maxLength": 63,


### PR DESCRIPTION
Closes https://github.com/giantswarm/roadmap/issues/2582

For details, see the issue.

The pattern in .metdata.labels did not include a slash, which is frequently used in K8s labels. I added it.

For confidence, I'm adding a label to the CI test values.

### Please check if PR meets these requirements

- [x] Results of the diffs have been examined and no unintended changes are being introduced.

### Trigger e2e tests

<!--
If for some reason you want to skip the e2e tests, remove the following lines.
-->

/run cluster-test-suites
