### PR TITLE
Simplify failureDomain title annotation

### DIFF
--- a/helm/cluster-azure/values.schema.json
+++ b/helm/cluster-azure/values.schema.json
@@ -444,7 +444,7 @@
                     },
                     "failureDomain": {
                         "type": "string",
-                        "title": "Select zone where to deploy the nodePool",
+                        "title": "Availability zone",
                         "enum": [
                             "1",
                             "2",


### PR DESCRIPTION
This PR changes the title of the `nodePools.*.failureDomain` property. The previous title

    Select zone where to deploy the nodePool

was phrased especially for as an instruction for the cluster creation / node pool creation use case. So I'm changing this to a more universal phrasing, more in line with the rest of the schema.

### Please check if PR meets these requirements

- [x] Results of the diffs have been examined and no unintended changes are being introduced.

