### PR TITLE
Set value for terminated pod gc threshold to be consistent with vintage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Set value for `controller-manager` `terminated-pod-gc-threshold` to `125` ( consistent with vintage )
+
 ## [0.0.26] - 2023-06-28
 
 ### Changed

--- a/helm/cluster-azure/templates/_kcp.tpl
+++ b/helm/cluster-azure/templates/_kcp.tpl
@@ -151,6 +151,7 @@ spec:
           bind-address: "0.0.0.0"
           logtostderr: "true"
           profiling: "false"
+          terminated-pod-gc-threshold: "125"
           allocate-node-cidrs: "true"
           cloud-config: /etc/kubernetes/azure.json
           cloud-provider: external


### PR DESCRIPTION
Towards https://github.com/giantswarm/klingel/issues/91

### Please check if PR meets these requirements

- [x] Results of the diffs have been examined and no unintended changes are being introduced.

### Helper

* to disable the GH Action generating manifests diffs for installations, between target and source branches, comment the `/no_diffs_printing` on the PR.

### Trigger e2e tests

<!--
If for some reason you want to skip the e2e tests, remove the following lines.
-->

/run cluster-test-suites
