### PR TITLE
reconcile containerd config with cluster aws

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Reconcile `containerd` configuration with cluster-aws
+  - add support for containerd registry mirrors
+  - add support for containerd registry credentials
+
+
+### Added
+
 - Set value for `controller-manager` `terminated-pod-gc-threshold` to `125` ( consistent with vintage )
 
 ## [0.0.26] - 2023-06-28

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Reconcile `containerd` configuration with cluster-aws
+- Render `containerd` configuration at cluster creation time
   - add support for containerd registry mirrors
   - add support for containerd registry credentials
 

--- a/helm/cluster-azure/README.md
+++ b/helm/cluster-azure/README.md
@@ -38,6 +38,15 @@ Properties within the `.connectivity` top-level object
 | `connectivity.bastion` | **Bastion host**|**Type:** `object`<br/>|
 | `connectivity.bastion.enabled` | **Enable bastion host for this cluster**|**Type:** `boolean`<br/>**Default:** `true`|
 | `connectivity.bastion.instanceType` | **VM size** - Type of virtual machine to use for the bastion host.|**Type:** `string`<br/>**Default:** `"Standard_D2s_v5"`|
+| `connectivity.containerRegistries` | **Container registries** - Endpoints and credentials configuration for container registries.|**Type:** `object`<br/>**Default:** `{"docker.io":[{"endpoint":"registry-1.docker.io"},{"endpoint":"giantswarm.azurecr.io"}]}`|
+| `connectivity.containerRegistries.*` | **Registries** - Container registries and mirrors|**Type:** `array`<br/>|
+| `connectivity.containerRegistries.*[*]` | **Registry**|**Type:** `object`<br/>|
+| `connectivity.containerRegistries.*[*].credentials` | **Credentials**|**Type:** `object`<br/>|
+| `connectivity.containerRegistries.*[*].credentials.auth` | **Auth** - Base64-encoded string from the concatenation of the username, a colon, and the password.|**Type:** `string`<br/>|
+| `connectivity.containerRegistries.*[*].credentials.identitytoken` | **Identity token** - Used to authenticate the user and obtain an access token for the registry.|**Type:** `string`<br/>|
+| `connectivity.containerRegistries.*[*].credentials.password` | **Password** - Used to authenticate for the registry with username/password.|**Type:** `string`<br/>|
+| `connectivity.containerRegistries.*[*].credentials.username` | **Username** - Used to authenticate for the registry with username/password.|**Type:** `string`<br/>|
+| `connectivity.containerRegistries.*[*].endpoint` | **Endpoint** - Endpoint for the container registry.|**Type:** `string`<br/>|
 | `connectivity.network` | **Network**|**Type:** `object`<br/>|
 | `connectivity.network.controlPlane` | **Control plane**|**Type:** `object`<br/>|
 | `connectivity.network.controlPlane.cidr` | **Subnet**|**Type:** `string`<br/>**Default:** `"10.0.0.0/20"`|
@@ -95,6 +104,10 @@ Properties within the `.internal` top-level object
 | `internal.network.vnet.resourceGroup` | **Resource group name** - Resource group where the existing VNet is deployed.|**Type:** `string`<br/>**Value pattern:** `^[-\w\._\(\)]+$`<br/>|
 | `internal.network.vpn` | **VPN configuration** - Internal VPN configuration that is susceptible to more frequent change|**Type:** `object`<br/>|
 | `internal.network.vpn.gatewayMode` | **VPN gateway mode**|**Type:** `string`<br/>**Default:** `"none"`|
+| `internal.sandboxContainerImage` | **Kubectl image**|**Type:** `object`<br/>|
+| `internal.sandboxContainerImage.name` | **Repository**|**Type:** `string`<br/>**Default:** `"giantswarm/pause"`|
+| `internal.sandboxContainerImage.registry` | **Registry**|**Type:** `string`<br/>**Default:** `"quay.io"`|
+| `internal.sandboxContainerImage.tag` | **Tag**|**Type:** `string`<br/>**Default:** `"3.9"`|
 
 ### Metadata
 Properties within the `.metadata` top-level object

--- a/helm/cluster-azure/files/etc/containerd/config.toml
+++ b/helm/cluster-azure/files/etc/containerd/config.toml
@@ -1,0 +1,50 @@
+version = 2
+
+# recommended defaults from https://github.com/containerd/containerd/blob/main/docs/ops.md#base-configuration
+# set containerd as a subreaper on linux when it is not running as PID 1
+subreaper = true
+# set containerd's OOM score
+oom_score = -999
+disabled_plugins = []
+[plugins."containerd.runtime.v1.linux"]
+# shim binary name/path
+shim = "containerd-shim"
+# runtime binary name/path
+runtime = "runc"
+# do not use a shim when starting containers, saves on memory but
+# live restore is not supported
+no_shim = false
+
+[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc]
+# setting runc.options unsets parent settings
+runtime_type = "io.containerd.runc.v2"
+[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc.options]
+SystemdCgroup = true
+[plugins."io.containerd.grpc.v1.cri"]
+sandbox_image = "{{ .Values.internal.sandboxContainerImage.registry }}/{{ .Values.internal.sandboxContainerImage.name }}:{{ .Values.internal.sandboxContainerImage.tag }}"
+
+[plugins."io.containerd.grpc.v1.cri".registry]
+  [plugins."io.containerd.grpc.v1.cri".registry.mirrors]
+  {{- range $host, $config := .Values.connectivity.containerRegistries }}
+    [plugins."io.containerd.grpc.v1.cri".registry.mirrors."{{$host}}"]
+      endpoint = [
+        {{- range $value := $config -}}
+        "https://{{$value.endpoint}}",
+        {{- end -}}
+    ]
+  {{- end }}
+[plugins."io.containerd.grpc.v1.cri".registry.configs]
+  {{ range $host, $config := .Values.connectivity.containerRegistries -}}
+    {{ range $value := $config -}}
+      {{ with $value.credentials -}}
+      [plugins."io.containerd.grpc.v1.cri".registry.configs."{{$value.endpoint}}".auth]
+      {{ if and .username .password -}}
+      auth = {{ printf "%s:%s" .username .password | b64enc | quote }}
+      {{- else if .auth -}}
+      auth = {{ .auth | quote }}
+      {{ else if .identitytoken -}}
+      identitytoken = {{ .identitytoken  | quote }}
+      {{- end }}
+    {{- end }}
+  {{- end }}
+{{- end }}

--- a/helm/cluster-azure/templates/_containerd-config-secret.yaml
+++ b/helm/cluster-azure/templates/_containerd-config-secret.yaml
@@ -1,0 +1,8 @@
+{{- define "containerd-config-secret" }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "resource.default.name" $ }}-containerd-configuration
+data:
+  registry-config.toml: {{ tpl ($.Files.Get "files/etc/containerd/config.toml") $ | b64enc | quote }}
+{{- end -}}

--- a/helm/cluster-azure/templates/_helpers.tpl
+++ b/helm/cluster-azure/templates/_helpers.tpl
@@ -213,8 +213,6 @@ See more details here https://github.com/giantswarm/roadmap/issues/2223.
 # Won't be needed anymore once https://github.com/giantswarm/capi-image-builder/pull/81 has been released and new images build out of it
 {{- define "override-pause-image-with-quay" -}}
 - sed -i -e 's/registry.k8s.io\/pause/quay.io\/giantswarm\/pause/' /etc/sysconfig/kubelet
-- sed -i -e 's/registry.k8s.io\/pause/quay.io\/giantswarm\/pause/' /etc/containerd/config.toml
-- systemctl restart containerd
 {{- end -}}
 
 {{/*
@@ -265,6 +263,15 @@ userAssignedIdentities:
     {{- end -}}
   {{- end -}}
 {{- end }}
+{{- end -}}
+
+{{- define "containerdConfig" -}}
+- path: /etc/containerd/config.toml
+  permissions: "0644"
+  contentFrom:
+    secret:
+      name: {{ include "resource.default.name" $ }}-containerd-configuration
+      key: registry-config.toml
 {{- end -}}
 
 {{/*

--- a/helm/cluster-azure/templates/_kcp.tpl
+++ b/helm/cluster-azure/templates/_kcp.tpl
@@ -181,6 +181,7 @@ spec:
     {{- include "kubeletReservationFiles" $ | nindent 4 }}
     {{- include "commonSysctlConfigurations" $ | nindent 4 }}
     {{- include "auditRules99Default" $ | nindent 4 }}
+    {{- include "containerdConfig" $ | nindent 4 }}
     - contentFrom:
         secret:
           key: control-plane-azure.json

--- a/helm/cluster-azure/templates/list.yaml
+++ b/helm/cluster-azure/templates/list.yaml
@@ -7,6 +7,8 @@
 ---
 {{- include "azure-cluster" . }}
 ---
+{{- include "containerd-config-secret" . }}
+---
 {{- include "control-plane" . }}
 ---
 {{- include "machine-deployments" . }}

--- a/helm/cluster-azure/values.schema.json
+++ b/helm/cluster-azure/values.schema.json
@@ -41,6 +41,66 @@
                         }
                     }
                 },
+                "containerRegistries": {
+                    "type": "object",
+                    "title": "Container registries",
+                    "description": "Endpoints and credentials configuration for container registries.",
+                    "additionalProperties": {
+                        "type": "array",
+                        "title": "Registries",
+                        "description": "Container registries and mirrors",
+                        "items": {
+                            "type": "object",
+                            "title": "Registry",
+                            "required": [
+                                "endpoint"
+                            ],
+                            "properties": {
+                                "credentials": {
+                                    "type": "object",
+                                    "title": "Credentials",
+                                    "properties": {
+                                        "auth": {
+                                            "type": "string",
+                                            "title": "Auth",
+                                            "description": "Base64-encoded string from the concatenation of the username, a colon, and the password."
+                                        },
+                                        "identitytoken": {
+                                            "type": "string",
+                                            "title": "Identity token",
+                                            "description": "Used to authenticate the user and obtain an access token for the registry."
+                                        },
+                                        "password": {
+                                            "type": "string",
+                                            "title": "Password",
+                                            "description": "Used to authenticate for the registry with username/password."
+                                        },
+                                        "username": {
+                                            "type": "string",
+                                            "title": "Username",
+                                            "description": "Used to authenticate for the registry with username/password."
+                                        }
+                                    }
+                                },
+                                "endpoint": {
+                                    "type": "string",
+                                    "title": "Endpoint",
+                                    "description": "Endpoint for the container registry."
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "docker.io": [
+                            {
+                                "endpoint": "registry-1.docker.io"
+                            },
+                            {
+                                "endpoint": "giantswarm.azurecr.io"
+                            }
+                        ]
+                    }
+                },
                 "network": {
                     "type": "object",
                     "title": "Network",
@@ -334,6 +394,27 @@
                                     "default": "none"
                                 }
                             }
+                        }
+                    }
+                },
+                "sandboxContainerImage": {
+                    "type": "object",
+                    "title": "Kubectl image",
+                    "properties": {
+                        "name": {
+                            "type": "string",
+                            "title": "Repository",
+                            "default": "giantswarm/pause"
+                        },
+                        "registry": {
+                            "type": "string",
+                            "title": "Registry",
+                            "default": "quay.io"
+                        },
+                        "tag": {
+                            "type": "string",
+                            "title": "Tag",
+                            "default": "3.9"
                         }
                     }
                 }

--- a/helm/cluster-azure/values.yaml
+++ b/helm/cluster-azure/values.yaml
@@ -6,6 +6,10 @@ connectivity:
   bastion:
     enabled: true
     instanceType: Standard_D2s_v5
+  containerRegistries:
+    docker.io:
+      - endpoint: registry-1.docker.io
+      - endpoint: giantswarm.azurecr.io
   network:
     controlPlane:
       cidr: 10.0.0.0/20
@@ -48,6 +52,10 @@ internal:
     vnet: {}
     vpn:
       gatewayMode: none
+  sandboxContainerImage:
+    name: giantswarm/pause
+    registry: quay.io
+    tag: "3.9"
 metadata:
   servicePriority: highest
 nodePools:


### PR DESCRIPTION
- Overwrite containerd configuration to support registry mirrors and credentials
- Update changelog


### Please check if PR meets these requirements

- [ ] Results of the diffs have been examined and no unintended changes are being introduced.

### Helper

* to disable the GH Action generating manifests diffs for installations, between target and source branches, comment the `/no_diffs_printing` on the PR.

### Trigger e2e tests

<!--
If for some reason you want to skip the e2e tests, remove the following lines.
-->

/run cluster-test-suites
