### PR TITLE
Split storage for control plane on multiple disks for kubelet,containerd,etcd and root volume.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Use multiple volumes for `containerd`,`kubelet`,`root` and `etcd` mounts for **control plane** nodes
+
 ## [0.0.27] - 2023-07-13
 
 ### Added

--- a/helm/cluster-azure/README.md
+++ b/helm/cluster-azure/README.md
@@ -63,8 +63,10 @@ Properties within the `.controlPlane` top-level object
 
 | **Property** | **Description** | **More Details** |
 | :----------- | :-------------- | :--------------- |
-| `controlPlane.etcdVolumeSizeGB` | **Etcd volume size (GB)**|**Type:** `integer`<br/>**Default:** `10`|
+| `controlPlane.containerdVolumeSizeGB` | **Containerd volume size (GB)**|**Type:** `integer`<br/>**Default:** `100`|
+| `controlPlane.etcdVolumeSizeGB` | **Etcd volume size (GB)**|**Type:** `integer`<br/>**Default:** `100`|
 | `controlPlane.instanceType` | **Node VM size**|**Type:** `string`<br/>**Default:** `"Standard_D4s_v3"`|
+| `controlPlane.kubeletVolumeSizeGB` | **Kubelet volume size (GB)**|**Type:** `integer`<br/>**Default:** `100`|
 | `controlPlane.oidc` | **OIDC authentication**|**Type:** `object`<br/>|
 | `controlPlane.oidc.caPem` | **Certificate authority** - Identity provider's CA certificate in PEM format.|**Type:** `string`<br/>**Default:** `""`|
 | `controlPlane.oidc.clientId` | **Client ID**|**Type:** `string`<br/>**Default:** `""`|

--- a/helm/cluster-azure/templates/_kcp.tpl
+++ b/helm/cluster-azure/templates/_kcp.tpl
@@ -10,6 +10,12 @@ dataDisks:
   - diskSizeGB: {{ $.Values.controlPlane.etcdVolumeSizeGB }}
     lun: 0
     nameSuffix: etcddisk
+  - diskSizeGB: {{ $.Values.controlPlane.containerdVolumeSizeGB }}
+    lun: 1
+    nameSuffix: containerddisk
+  - diskSizeGB: {{ $.Values.controlPlane.kubeletVolumeSizeGB }}
+    lun: 2
+    nameSuffix: kubeletdisk
 osDisk:
   diskSizeGB: {{ $.Values.controlPlane.rootVolumeSizeGB }}
   osType: Linux
@@ -49,6 +55,20 @@ spec:
         filesystem: ext4
         label: etcd_disk
         overwrite: false
+      - device: /dev/disk/azure/scsi1/lun1
+        extraOpts:
+        - -E
+        - lazy_itable_init=1,lazy_journal_init=1
+        filesystem: ext4
+        label: containerd_disk
+        overwrite: false
+      - device: /dev/disk/azure/scsi1/lun2
+        extraOpts:
+        - -E
+        - lazy_itable_init=1,lazy_journal_init=1
+        filesystem: ext4
+        label: kubelet_disk
+        overwrite: false
       #partitions:
       #- device: /dev/disk/azure/scsi1/lun0
       #  layout: true
@@ -57,6 +77,10 @@ spec:
     mounts:
     - - etcd_disk
       - /var/lib/etcddisk
+    - - containerd_disk
+      - /var/lib/containerd
+    - - kubelet_disk
+      - /var/lib/kubelet
     format: ignition
     ignition:
       containerLinuxConfig:

--- a/helm/cluster-azure/templates/_machine_helpers.tpl
+++ b/helm/cluster-azure/templates/_machine_helpers.tpl
@@ -9,7 +9,7 @@ image:
     name: {{ include "flatcarImageName" $ }}
     version: {{ $.Values.internal.image.version }}
 osDisk:
-  diskSizeGB: {{ .spec.rootVolumeSizeGB }}
+  diskSizeGB: {{ .spec.rootVolumeSizeGB | default 300 }}
   managedDisk:
     storageAccountType: Premium_LRS
   osType: Linux

--- a/helm/cluster-azure/values.schema.json
+++ b/helm/cluster-azure/values.schema.json
@@ -233,7 +233,7 @@
                     "type": "integer",
                     "title": "Root volume size (GB)",
                     "default": 50,
-                    "exclusiveMinimum": 20
+                    "minimum": 20
                 }
             }
         },

--- a/helm/cluster-azure/values.schema.json
+++ b/helm/cluster-azure/values.schema.json
@@ -227,7 +227,7 @@
                     "type": "integer",
                     "title": "Number of nodes",
                     "default": 3,
-                    "minimum": 20
+                    "exclusiveMinimum": 0
                 },
                 "rootVolumeSizeGB": {
                     "type": "integer",

--- a/helm/cluster-azure/values.schema.json
+++ b/helm/cluster-azure/values.schema.json
@@ -172,13 +172,13 @@
                     "type": "integer",
                     "title": "Containerd volume size (GB)",
                     "default": 100,
-                    "exclusiveMinimum": 20
+                    "minimum": 20
                 },
                 "etcdVolumeSizeGB": {
                     "type": "integer",
                     "title": "Etcd volume size (GB)",
                     "default": 100,
-                    "exclusiveMinimum": 20
+                    "minimum": 20
                 },
                 "instanceType": {
                     "type": "string",
@@ -189,7 +189,7 @@
                     "type": "integer",
                     "title": "Kubelet volume size (GB)",
                     "default": 100,
-                    "exclusiveMinimum": 20
+                    "minimum": 20
                 },
                 "oidc": {
                     "type": "object",
@@ -227,7 +227,7 @@
                     "type": "integer",
                     "title": "Number of nodes",
                     "default": 3,
-                    "exclusiveMinimum": 0
+                    "minimum": 20
                 },
                 "rootVolumeSizeGB": {
                     "type": "integer",

--- a/helm/cluster-azure/values.schema.json
+++ b/helm/cluster-azure/values.schema.json
@@ -168,16 +168,28 @@
             "type": "object",
             "title": "Control plane",
             "properties": {
+                "containerdVolumeSizeGB": {
+                    "type": "integer",
+                    "title": "Containerd volume size (GB)",
+                    "default": 100,
+                    "exclusiveMinimum": 20
+                },
                 "etcdVolumeSizeGB": {
                     "type": "integer",
                     "title": "Etcd volume size (GB)",
-                    "default": 10,
-                    "exclusiveMinimum": 0
+                    "default": 100,
+                    "exclusiveMinimum": 20
                 },
                 "instanceType": {
                     "type": "string",
                     "title": "Node VM size",
                     "default": "Standard_D4s_v3"
+                },
+                "kubeletVolumeSizeGB": {
+                    "type": "integer",
+                    "title": "Kubelet volume size (GB)",
+                    "default": 100,
+                    "exclusiveMinimum": 20
                 },
                 "oidc": {
                     "type": "object",
@@ -221,7 +233,7 @@
                     "type": "integer",
                     "title": "Root volume size (GB)",
                     "default": 50,
-                    "exclusiveMinimum": 0
+                    "exclusiveMinimum": 20
                 }
             }
         },

--- a/helm/cluster-azure/values.yaml
+++ b/helm/cluster-azure/values.yaml
@@ -21,8 +21,10 @@ connectivity:
       cidr: 10.0.16.0/20
   sshSSOPublicKey: ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIM4cvZ01fLmO9cJbWUj7sfF+NhECgy+Cl0bazSrZX7sU vault-ca@vault.operations.giantswarm.io
 controlPlane:
-  etcdVolumeSizeGB: 10
+  containerdVolumeSizeGB: 100
+  etcdVolumeSizeGB: 100
   instanceType: Standard_D4s_v3
+  kubeletVolumeSizeGB: 100
   oidc:
     caPem: ""
     clientId: ""


### PR DESCRIPTION
* Match control plane setup for cluster-aws ( 100GB for each disk by default )
* Also match default size of root disk for worker nodes to be the same as AWS at 300GB

Towards - https://github.com/giantswarm/giantswarm/issues/25357

### Please check if PR meets these requirements

- [ ] Results of the diffs have been examined and no unintended changes are being introduced.

### Helper

* to disable the GH Action generating manifests diffs for installations, between target and source branches, comment the `/no_diffs_printing` on the PR.

### Trigger e2e tests

<!--
If for some reason you want to skip the e2e tests, remove the following lines.
-->

/run cluster-test-suites
