### PR TITLE
Add regelar expression and max length to cluster machinepool name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add validation of cluster name using Schema Regex
+
 ## [0.0.29] - 2023-08-03
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Add validation of cluster name using Schema Regex
+- Add validation of machineDeployment name using Schema Regex
 
 ## [0.0.29] - 2023-08-03
 

--- a/helm/cluster-azure/README.md
+++ b/helm/cluster-azure/README.md
@@ -143,7 +143,7 @@ Properties within the `.nodePools` top-level object
 | `nodePools[*].disableHealthCheck` | **Disable HealthChecks for the MachineDeployment**|**Type:** `boolean`<br/>|
 | `nodePools[*].failureDomain` | **Availability zone**|**Type:** `string`<br/>|
 | `nodePools[*].instanceType` | **VM size**|**Type:** `string`<br/>|
-| `nodePools[*].name` | **Name** - Unique identifier, cannot be changed after creation.|**Type:** `string`<br/>|
+| `nodePools[*].name` | **Name** - Unique identifier, cannot be changed after creation.|**Type:** `string`<br/>**Value pattern:** `^[-\w\._]+$`<br/>|
 | `nodePools[*].replicas` | **Number of nodes**|**Type:** `integer`<br/>|
 | `nodePools[*].rootVolumeSizeGB` | **Root volume size (GB)**|**Type:** `integer`<br/>|
 

--- a/helm/cluster-azure/values.schema.json
+++ b/helm/cluster-azure/values.schema.json
@@ -579,7 +579,10 @@
                     "name": {
                         "type": "string",
                         "title": "Name",
-                        "description": "Unique identifier, cannot be changed after creation."
+                        "description": "Unique identifier, cannot be changed after creation.",
+                        "maxLength": 10,
+                        "minLength": 3,
+                        "pattern": "^[-\\w\\._]+$"
                     },
                     "replicas": {
                         "type": "integer",


### PR DESCRIPTION
As defined in https://github.com/giantswarm/kyverno-policies-ux/pull/38/files only 10 chars are allowed since the <CLUSTER_NAME>- is automatically added by the template

The `CLUSTER_NAME` is the name of the CR and so it can't be checked here as part of the schema ( which only check the helm values ) 

Towards https://github.com/giantswarm/giantswarm/issues/27306


### Please check if PR meets these requirements

- [ ] Results of the diffs have been examined and no unintended changes are being introduced.

### Helper

* to disable the GH Action generating manifests diffs for installations, between target and source branches, comment the `/no_diffs_printing` on the PR.

### Trigger e2e tests

<!--
If for some reason you want to skip the e2e tests, remove the following lines.
-->

/run cluster-test-suites
