### PR TITLE
Fix containerd plugin

### DIFF
--- a/helm/cluster-azure/files/etc/containerd/config.toml
+++ b/helm/cluster-azure/files/etc/containerd/config.toml
@@ -6,7 +6,7 @@ subreaper = true
 # set containerd's OOM score
 oom_score = -999
 disabled_plugins = []
-[plugins."containerd.runtime.v1.linux"]
+[plugins."io.containerd.runtime.v1.linux"]
 # shim binary name/path
 shim = "containerd-shim"
 # runtime binary name/path


### PR DESCRIPTION
I noticed this issue while switching cluster-vsphere to Flatcar. Containerd's newest version gives an error for this wrong key. This needs to be checked in CAPA side too.


### Please check if PR meets these requirements

- [ ] Results of the diffs have been examined and no unintended changes are being introduced.

### Helper

* to disable the GH Action generating manifests diffs for installations, between target and source branches, comment the `/no_diffs_printing` on the PR.

### Trigger e2e tests

<!--
If for some reason you want to skip the e2e tests, remove the following lines.
-->

/run cluster-test-suites
