### PR TITLE
Fix containerd config for flatcar 3602+

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add validation of machineDeployment name using Schema Regex
 
+### Fixed
+
+- Fix containerd config that was breaking in newer flatcar versions.
+
 ## [0.0.29] - 2023-08-03
 
 ### Changed

--- a/helm/cluster-azure/files/etc/containerd/config.toml
+++ b/helm/cluster-azure/files/etc/containerd/config.toml
@@ -6,7 +6,7 @@ subreaper = true
 # set containerd's OOM score
 oom_score = -999
 disabled_plugins = []
-[plugins."containerd.runtime.v1.linux"]
+[plugins."io.containerd.runtime.v1.linux"]
 # shim binary name/path
 shim = "containerd-shim"
 # runtime binary name/path


### PR DESCRIPTION
Fixes containerd config that is breaking in newer flatcar versions.
Same as: 
- https://github.com/giantswarm/cluster-aws/pull/421
- https://github.com/giantswarm/cluster-cloud-director/pull/222

### Please check if PR meets these requirements

- [x] Results of the diffs have been examined and no unintended changes are being introduced.

### Helper

* to disable the GH Action generating manifests diffs for installations, between target and source branches, comment the `/no_diffs_printing` on the PR.

### Trigger e2e tests

<!--
If for some reason you want to skip the e2e tests, remove the following lines.
-->

/run cluster-test-suites
