### PR TITLE
Add PSP switch so that users can disable PSPs before 1.25 upgrades

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Add validation of machineDeployment name using Schema Regex
+- Add flags to disable PSPs.
 
 ### Fixed
 

--- a/helm/cluster-azure/Chart.lock
+++ b/helm/cluster-azure/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: cluster-shared
   repository: https://giantswarm.github.io/cluster-catalog
-  version: 0.6.5
-digest: sha256:954be7fbf2365fca44d3a84aaf0e5272d9022f3146d4d9ead38f8e1e275a92f8
-generated: "2023-05-31T14:59:49.363419222+02:00"
+  version: 0.7.0
+digest: sha256:057d4c81b2884488aeb9a39ae5658394efbb97226e9eb168749e93ba72c35bf0
+generated: "2023-12-04T12:21:51.105349+03:00"

--- a/helm/cluster-azure/Chart.yaml
+++ b/helm/cluster-azure/Chart.yaml
@@ -16,5 +16,5 @@ restrictions:
     - capz
 dependencies:
 - name: cluster-shared
-  version: "0.6.5"
+  version: "0.7.0"
   repository: "https://giantswarm.github.io/cluster-catalog"

--- a/helm/cluster-azure/README.md
+++ b/helm/cluster-azure/README.md
@@ -151,6 +151,13 @@ Properties within the `.nodePools` top-level object
 | `nodePools[*].replicas` | **Number of nodes**|**Type:** `integer`<br/>|
 | `nodePools[*].rootVolumeSizeGB` | **Root volume size (GB)**|**Type:** `integer`<br/>|
 
+### Pod Security Standards
+Properties within the `.global.podSecurityStandards` object
+
+| **Property** | **Description** | **More Details** |
+| :----------- | :-------------- | :--------------- |
+| `global.podSecurityStandards.enforced` | **Enforced Pod Security Standards** - Use PSSs instead of PSPs.|**Type:** `boolean`<br/>**Default:** `false`|
+
 ### Other
 
 | **Property** | **Description** | **More Details** |

--- a/helm/cluster-azure/templates/_cluster.tpl
+++ b/helm/cluster-azure/templates/_cluster.tpl
@@ -9,6 +9,9 @@ metadata:
     {{- if .Values.metadata.servicePriority }}
     giantswarm.io/service-priority: {{ .Values.metadata.servicePriority }}
     {{- end }}
+    {{- if .Values.global.podSecurityStandards.enforced }}
+    policy.giantswarm.io/psp-status: disabled
+    {{- end }}
     {{- include "labels.common" $ | nindent 4 }}
     {{- if .Values.metadata.labels }}
     {{- range $key, $val := .Values.metadata.labels }}

--- a/helm/cluster-azure/templates/helmreleases/cni.yaml
+++ b/helm/cluster-azure/templates/helmreleases/cni.yaml
@@ -57,3 +57,6 @@ spec:
           operator: Exists
         - key: CriticalAddonsOnly
           operator: Exists
+    global:
+      podSecurityStandards:
+        enforced: {{ .Values.global.podSecurityStandards.enforced }}

--- a/helm/cluster-azure/templates/helmreleases/coredns.yaml
+++ b/helm/cluster-azure/templates/helmreleases/coredns.yaml
@@ -48,3 +48,7 @@ spec:
           clusterIPRange: {{ .Values.connectivity.network.serviceCidr | quote }}
         DNS:
           IP: {{ include "clusterDNS" $ | quote }}
+    global:
+      podSecurityStandards:
+        enforced: {{ .Values.global.podSecurityStandards.enforced }}
+

--- a/helm/cluster-azure/templates/helmreleases/cpi.yaml
+++ b/helm/cluster-azure/templates/helmreleases/cpi.yaml
@@ -46,6 +46,9 @@ spec:
     controller:
       azureCredentialFile: "/etc/kubernetes/azure.json"
       kubeconfigFromHost: false
+    global:
+      podSecurityStandards:
+        enforced: {{ .Values.global.podSecurityStandards.enforced }}
 ---
 apiVersion: helm.toolkit.fluxcd.io/v2beta1
 kind: HelmRelease
@@ -87,3 +90,7 @@ spec:
   values:
     verticalPodAutoscaler:
       enabled: {{ .Values.internal.enableVpaResources }}
+    global:
+      podSecurityStandards:
+        enforced: {{ .Values.global.podSecurityStandards.enforced }}
+

--- a/helm/cluster-azure/templates/helmreleases/cpi.yaml
+++ b/helm/cluster-azure/templates/helmreleases/cpi.yaml
@@ -21,7 +21,7 @@ spec:
       chart: azure-cloud-controller-manager-app
       # used by renovate
       # repo: giantswarm/azure-cloud-controller-manager-app
-      version: 1.24.18-gs4
+      version: 1.24.18-gs5
       sourceRef:
         kind: HelmRepository
         name: {{ include "resource.default.name" $ }}-default
@@ -73,7 +73,7 @@ spec:
       chart: azure-cloud-node-manager-app
       # used by renovate
       # repo: giantswarm/azure-cloud-node-manager-app
-      version: 1.24.18-gs3
+      version: 1.24.18-gs5
       sourceRef:
         kind: HelmRepository
         name: {{ include "resource.default.name" $ }}-default
@@ -93,4 +93,6 @@ spec:
     global:
       podSecurityStandards:
         enforced: {{ .Values.global.podSecurityStandards.enforced }}
+    # kyverno installs PolicyException CRs for core components on CAPI clusters
+    deployPolicyExceptions: false
 

--- a/helm/cluster-azure/templates/helmreleases/csi.yaml
+++ b/helm/cluster-azure/templates/helmreleases/csi.yaml
@@ -52,3 +52,6 @@ spec:
     snapshot:
       verticalPodAutoscaler:
         enabled: {{ .Values.internal.enableVpaResources }}
+    global:
+      podSecurityStandards:
+        enforced: {{ .Values.global.podSecurityStandards.enforced }}

--- a/helm/cluster-azure/templates/helmreleases/csi.yaml
+++ b/helm/cluster-azure/templates/helmreleases/csi.yaml
@@ -21,7 +21,7 @@ spec:
       chart: azuredisk-csi-driver-app
       # used by renovate
       # repo: giantswarm/azuredisk-csi-driver-app
-      version: 1.27.0
+      version: 1.26.2-gs5
       sourceRef:
         kind: HelmRepository
         name: {{ include "resource.default.name" $ }}-default

--- a/helm/cluster-azure/templates/helmreleases/vpa-crd-helmrelease.yaml
+++ b/helm/cluster-azure/templates/helmreleases/vpa-crd-helmrelease.yaml
@@ -28,3 +28,8 @@ spec:
   install:
     remediation:
       retries: 30
+  values:
+    global:
+      podSecurityStandards:
+        enforced: {{ .Values.global.podSecurityStandards.enforced }}
+

--- a/helm/cluster-azure/templates/list.yaml
+++ b/helm/cluster-azure/templates/list.yaml
@@ -1,4 +1,4 @@
-{{- if semverCompare "<1.25.0" .Capabilities.KubeVersion.Version -}}
+{{- if semverCompare "<1.25.0" .Values.internal.kubernetesVersion -}}
 ---
 {{- include "psps" . }}
 {{- end }}

--- a/helm/cluster-azure/values.schema.json
+++ b/helm/cluster-azure/values.schema.json
@@ -237,6 +237,24 @@
                 }
             }
         },
+        "global": {
+            "type": "object",
+            "title": "Global parameters",
+            "properties": {
+                "podSecurityStandards": {
+                    "type": "object",
+                    "title": "Pod Security Standards",
+                    "properties": {
+                        "enforced": {
+                            "type": "boolean",
+                            "title": "Enforced Pod Security Standards",
+                            "description": "Use PSSs instead of PSPs.",
+                            "default": false
+                        }
+                    }
+                }
+            }
+        },
         "internal": {
             "type": "object",
             "title": "Internal settings",

--- a/helm/cluster-azure/values.yaml
+++ b/helm/cluster-azure/values.yaml
@@ -33,6 +33,9 @@ controlPlane:
     usernameClaim: ""
   replicas: 3
   rootVolumeSizeGB: 50
+global:
+  podSecurityStandards:
+    enforced: false
 internal:
   defaults:
     evictionMinimumReclaim: imagefs.available=5%,memory.available=100Mi,nodefs.available=5%


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/2970

Steps for migration to 1.25
- Consume default-apps-azure version with PSSs -> https://github.com/giantswarm/default-apps-azure/pull/179
- Bump cluster-azure version to consume this PR
- Edit user-values and set `global.podSecurityStandards.enforced=true`
- Observe PSPs are not affective in the WC anymore -> See https://github.com/giantswarm/cluster-shared/pull/70
- Bump k8s version to 1.25
- Observe everything is up&running

These steps are tested manually by @erkanerol 
