### PR TITLE
Update default image to 1.24.17

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Enable teleport by default.
+- Upgrade Flatcar image to [3510.2.5](https://www.flatcar.org/releases#release-3510.2.5)
+- Upgrade K8S version to `1.24.17`
+
 ## [0.0.31] - 2023-12-14
 
 ### Added
@@ -23,10 +28,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fix containerd config that was breaking in newer flatcar versions.
-
-### Changed
-
-- Enable teleport by default.
 
 ## [0.0.29] - 2023-08-03
 

--- a/helm/cluster-azure/README.md
+++ b/helm/cluster-azure/README.md
@@ -95,12 +95,12 @@ Properties within the `.internal` top-level object
 | `internal.image` | **Node Image**|**Type:** `object`<br/>|
 | `internal.image.gallery` | **Gallery** - Name of the community gallery hosting the image|**Type:** `string`<br/>**Default:** `"gsCapzFlatcar-41c2d140-ac44-4d8b-b7e1-7b2f1ddbe4d0"`|
 | `internal.image.name` | **Image Definition** - Name of the image definition in the Gallery|**Type:** `string`<br/>**Default:** `""`|
-| `internal.image.version` | **Image version**|**Type:** `string`<br/>**Default:** `"3510.2.1"`|
+| `internal.image.version` | **Image version**|**Type:** `string`<br/>**Default:** `"3510.2.5"`|
 | `internal.kubectlImage` | **Kubectl Image settings**|**Type:** `object`<br/>|
 | `internal.kubectlImage.name` | **Image name** - Name of the image Registry|**Type:** `string`<br/>**Default:** `"giantswarm/kubectl"`|
 | `internal.kubectlImage.registry` | **Kubectl Image Registry** - Registry for the kubectl image|**Type:** `string`<br/>**Default:** `"quay.io"`|
 | `internal.kubectlImage.tag` | **Image tag**|**Type:** `string`<br/>**Default:** `"1.23.5"`|
-| `internal.kubernetesVersion` | **Kubernetes version**|**Type:** `string`<br/>**Default:** `"1.24.13"`|
+| `internal.kubernetesVersion` | **Kubernetes version**|**Type:** `string`<br/>**Default:** `"1.24.17"`|
 | `internal.network` | **Network configuration** - Internal network configuration that is susceptible to more frequent change|**Type:** `object`<br/>|
 | `internal.network.subnets` | **VNet spec** - Customize subnets configuration|**Type:** `object`<br/>**Default:** `{}`|
 | `internal.network.subnets.controlPlaneSubnetName` | **ControlPlane subnet name** - Name of the control plane subnet.|**Type:** `string`<br/>**Value pattern:** `^[-\w\._]+$`<br/>|

--- a/helm/cluster-azure/templates/_helpers.tpl
+++ b/helm/cluster-azure/templates/_helpers.tpl
@@ -46,12 +46,12 @@ room for such suffix.
 {{- end -}}
 
 {{/*
-The default name for our images in the Community Gallery is  "capi-flatcar-stable-<KUBERNETES_VERSION>-gen2",
+The default name for our images in the Community Gallery is  "capi-flatcar-stable-<KUBERNETES_VERSION>-gen2-gs",
 use it when no value is passed in
 */}}
 {{- define "flatcarImageName" -}}
 {{- if empty .Values.internal.image.name -}}
-{{ printf "capi-flatcar-stable-%s-gen2" .Values.internal.kubernetesVersion }}
+{{ printf "capi-flatcar-stable-%s-gen2-gs" .Values.internal.kubernetesVersion }}
 {{- else -}}
 {{ .Values.internal.image.name }}
 {{- end -}}

--- a/helm/cluster-azure/values.schema.json
+++ b/helm/cluster-azure/values.schema.json
@@ -343,7 +343,7 @@
                         "version": {
                             "type": "string",
                             "title": "Image version",
-                            "default": "3510.2.1"
+                            "default": "3510.2.5"
                         }
                     }
                 },
@@ -373,7 +373,7 @@
                 "kubernetesVersion": {
                     "type": "string",
                     "title": "Kubernetes version",
-                    "default": "1.24.13"
+                    "default": "1.24.17"
                 },
                 "network": {
                     "type": "object",

--- a/helm/cluster-azure/values.yaml
+++ b/helm/cluster-azure/values.yaml
@@ -51,12 +51,12 @@ internal:
   image:
     gallery: gsCapzFlatcar-41c2d140-ac44-4d8b-b7e1-7b2f1ddbe4d0
     name: ""
-    version: 3510.2.1
+    version: 3510.2.5
   kubectlImage:
     name: giantswarm/kubectl
     registry: quay.io
     tag: 1.23.5
-  kubernetesVersion: 1.24.13
+  kubernetesVersion: 1.24.17
   network:
     subnets: {}
     vnet: {}


### PR DESCRIPTION
This PR updates the default image and k8s version.  We have this new image in the gallery and it contains `teleport` binary. 


### Trigger e2e tests

/run cluster-test-suites
