### PR TITLE
Fix clean-up issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
+
 - Enable teleport by default.
 - Upgrade Flatcar image to [3510.2.5](https://www.flatcar.org/releases#release-3510.2.5)
 - Upgrade K8S version to `1.24.17`
+- Fix left-over azurefile-csi-driver helmreleases during cleanup.
 
 ## [0.0.31] - 2023-12-14
 

--- a/helm/cluster-azure/templates/helmreleases/cleanup-helmreleases-hook-job.yaml
+++ b/helm/cluster-azure/templates/helmreleases/cleanup-helmreleases-hook-job.yaml
@@ -52,6 +52,7 @@ rules:
       - "{{ include "resource.default.name" $ }}-azure-cloud-controller-manager"
       - "{{ include "resource.default.name" $ }}-azure-cloud-node-manager"
       - "{{ include "resource.default.name" $ }}-azuredisk-csi-driver"
+      - "{{ include "resource.default.name" $ }}-azurefile-csi-driver"
       - "{{ include "resource.default.name" $ }}-coredns"
       - "{{ include "resource.default.name" $ }}-vertical-pod-autoscaler-crd"
     verbs: ["patch"]


### PR DESCRIPTION
I recently added azurefile-csi-driver-app with https://github.com/giantswarm/cluster-azure/pull/188 I started observing some left-over helmreleases of this app and found that it is missing in the cleanup list.  