### PR TITLE
Bump  default k8s version to 1.25

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Use `Standard_D4s_v5` for control plane and worker nodes.
 - Use 2 replicas for workers by default.
+- Upgrade K8S version to `1.25.16`.
+- Upgrade kubectl version to `1.25.15`.
+- Disable PSPs by default.
 
 ## [0.0.35] - 2024-02-07
 

--- a/helm/cluster-azure/README.md
+++ b/helm/cluster-azure/README.md
@@ -96,8 +96,8 @@ Properties within the `.internal` top-level object
 | `internal.kubectlImage` | **Kubectl Image settings**|**Type:** `object`<br/>|
 | `internal.kubectlImage.name` | **Image name** - Name of the image Registry|**Type:** `string`<br/>**Default:** `"giantswarm/kubectl"`|
 | `internal.kubectlImage.registry` | **Kubectl Image Registry** - Registry for the kubectl image|**Type:** `string`<br/>**Default:** `"gsoci.azurecr.io"`|
-| `internal.kubectlImage.tag` | **Image tag**|**Type:** `string`<br/>**Default:** `"1.23.5"`|
-| `internal.kubernetesVersion` | **Kubernetes version**|**Type:** `string`<br/>**Default:** `"1.24.17"`|
+| `internal.kubectlImage.tag` | **Image tag**|**Type:** `string`<br/>**Default:** `"1.25.15"`|
+| `internal.kubernetesVersion` | **Kubernetes version**|**Type:** `string`<br/>**Default:** `"1.25.16"`|
 | `internal.network` | **Network configuration** - Internal network configuration that is susceptible to more frequent change|**Type:** `object`<br/>|
 | `internal.network.subnets` | **VNet spec** - Customize subnets configuration|**Type:** `object`<br/>**Default:** `{}`|
 | `internal.network.subnets.controlPlaneSubnetName` | **ControlPlane subnet name** - Name of the control plane subnet.|**Type:** `string`<br/>**Value pattern:** `^[-\w\._]+$`<br/>|
@@ -154,7 +154,7 @@ Properties within the `.global.podSecurityStandards` object
 
 | **Property** | **Description** | **More Details** |
 | :----------- | :-------------- | :--------------- |
-| `global.podSecurityStandards.enforced` | **Enforced Pod Security Standards** - Use PSSs instead of PSPs.|**Type:** `boolean`<br/>**Default:** `false`|
+| `global.podSecurityStandards.enforced` | **Enforced Pod Security Standards** - Use PSSs instead of PSPs.|**Type:** `boolean`<br/>**Default:** `true`|
 
 ### Other
 

--- a/helm/cluster-azure/values.schema.json
+++ b/helm/cluster-azure/values.schema.json
@@ -233,7 +233,7 @@
                             "type": "boolean",
                             "title": "Enforced Pod Security Standards",
                             "description": "Use PSSs instead of PSPs.",
-                            "default": false
+                            "default": true
                         }
                     }
                 }
@@ -350,14 +350,14 @@
                         "tag": {
                             "type": "string",
                             "title": "Image tag",
-                            "default": "1.23.5"
+                            "default": "1.25.15"
                         }
                     }
                 },
                 "kubernetesVersion": {
                     "type": "string",
                     "title": "Kubernetes version",
-                    "default": "1.24.17"
+                    "default": "1.25.16"
                 },
                 "network": {
                     "type": "object",

--- a/helm/cluster-azure/values.yaml
+++ b/helm/cluster-azure/values.yaml
@@ -32,7 +32,7 @@ controlPlane:
   rootVolumeSizeGB: 50
 global:
   podSecurityStandards:
-    enforced: false
+    enforced: true
 internal:
   defaults:
     evictionMinimumReclaim: imagefs.available=5%,memory.available=100Mi,nodefs.available=5%
@@ -52,8 +52,8 @@ internal:
   kubectlImage:
     name: giantswarm/kubectl
     registry: gsoci.azurecr.io
-    tag: 1.23.5
-  kubernetesVersion: 1.24.17
+    tag: 1.25.15
+  kubernetesVersion: 1.25.16
   network:
     subnets: {}
     vnet: {}


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/29801

We are ready to make 1.25 default. MCs support 1.25 WCs.