### PR TITLE
Enable Host Encryption for workers and control plane virtual machines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Enable Host Encryption for workers and control plane virtual machines.
+
 ## [0.0.32] - 2023-12-20
 
 ### Changed
@@ -347,4 +351,3 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [0.0.2]: https://github.com/giantswarm/cluster-azure/compare/v0.0.1...v0.0.2
 [0.0.1]: https://github.com/giantswarm/cluster-azure/compare/v0.0.1...v0.0.1
 [0.0.1]: https://github.com/giantswarm/cluster-azure/releases/tag/v0.0.1
-

--- a/helm/cluster-azure/README.md
+++ b/helm/cluster-azure/README.md
@@ -64,6 +64,7 @@ Properties within the `.controlPlane` top-level object
 | **Property** | **Description** | **More Details** |
 | :----------- | :-------------- | :--------------- |
 | `controlPlane.containerdVolumeSizeGB` | **Containerd volume size (GB)**|**Type:** `integer`<br/>**Default:** `100`|
+| `controlPlane.encryptionAtHost` | **Encryption at host** - Enable encryption at host for the control plane nodes.|**Type:** `boolean`<br/>**Default:** `false`|
 | `controlPlane.etcdVolumeSizeGB` | **Etcd volume size (GB)**|**Type:** `integer`<br/>**Default:** `100`|
 | `controlPlane.instanceType` | **Node VM size**|**Type:** `string`<br/>**Default:** `"Standard_D4s_v3"`|
 | `controlPlane.kubeletVolumeSizeGB` | **Kubelet volume size (GB)**|**Type:** `integer`<br/>**Default:** `100`|
@@ -145,6 +146,7 @@ Properties within the `.nodePools` top-level object
 | `nodePools[*].customNodeTaints[*].key` | **Key**|**Type:** `string`<br/>|
 | `nodePools[*].customNodeTaints[*].value` | **Value**|**Type:** `string`<br/>|
 | `nodePools[*].disableHealthCheck` | **Disable HealthChecks for the MachineDeployment**|**Type:** `boolean`<br/>|
+| `nodePools[*].encryptionAtHost` | **Encryption at host** - Enable encryption at host for the worker nodes.|**Type:** `boolean`<br/>**Default:** `false`|
 | `nodePools[*].failureDomain` | **Availability zone**|**Type:** `string`<br/>|
 | `nodePools[*].instanceType` | **VM size**|**Type:** `string`<br/>|
 | `nodePools[*].name` | **Name** - Unique identifier, cannot be changed after creation.|**Type:** `string`<br/>**Value pattern:** `^[-\w\._]+$`<br/>|

--- a/helm/cluster-azure/templates/_kcp.tpl
+++ b/helm/cluster-azure/templates/_kcp.tpl
@@ -19,6 +19,8 @@ dataDisks:
 osDisk:
   diskSizeGB: {{ $.Values.controlPlane.rootVolumeSizeGB }}
   osType: Linux
+securityProfile:
+  encryptionAtHost: {{ $.Values.controlPlane.encryptionAtHost }}
 sshPublicKey: {{ include "fake-rsa-ssh-key" $ | b64enc }}
 vmSize: {{ $.Values.controlPlane.instanceType }}
 {{- if ( include "network.subnets.controlPlane.name" $ ) }}

--- a/helm/cluster-azure/templates/_machine_helpers.tpl
+++ b/helm/cluster-azure/templates/_machine_helpers.tpl
@@ -13,6 +13,8 @@ osDisk:
   managedDisk:
     storageAccountType: Premium_LRS
   osType: Linux
+securityProfile:
+  encryptionAtHost: {{ .spec.encryptionAtHost }}
 sshPublicKey: {{ include "fake-rsa-ssh-key" $ | b64enc }}
 vmSize: {{ .spec.instanceType }}
 {{- if ( include "network.subnets.nodes.name" $ ) }}

--- a/helm/cluster-azure/values.schema.json
+++ b/helm/cluster-azure/values.schema.json
@@ -174,6 +174,12 @@
                     "default": 100,
                     "minimum": 20
                 },
+                "encryptionAtHost": {
+                    "type": "boolean",
+                    "title": "Encryption at host",
+                    "description": "Enable encryption at host for the control plane nodes.",
+                    "default": false
+                },
                 "etcdVolumeSizeGB": {
                     "type": "integer",
                     "title": "Etcd volume size (GB)",
@@ -602,6 +608,12 @@
                         "type": "boolean",
                         "title": "Disable HealthChecks for the MachineDeployment"
                     },
+                    "encryptionAtHost": {
+                        "type": "boolean",
+                        "title": "Encryption at host",
+                        "description": "Enable encryption at host for the worker nodes.",
+                        "default": false
+                    },
                     "failureDomain": {
                         "type": "string",
                         "title": "Availability zone",
@@ -640,6 +652,7 @@
                     "customNodeLabels": [],
                     "customNodeTaints": [],
                     "disableHealthCheck": false,
+                    "encryptionAtHost": false,
                     "instanceType": "Standard_D2s_v3",
                     "name": "md00",
                     "replicas": 3,

--- a/helm/cluster-azure/values.yaml
+++ b/helm/cluster-azure/values.yaml
@@ -22,6 +22,7 @@ connectivity:
   sshSSOPublicKey: ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIM4cvZ01fLmO9cJbWUj7sfF+NhECgy+Cl0bazSrZX7sU vault-ca@vault.operations.giantswarm.io
 controlPlane:
   containerdVolumeSizeGB: 100
+  encryptionAtHost: false
   etcdVolumeSizeGB: 100
   instanceType: Standard_D4s_v3
   kubeletVolumeSizeGB: 100
@@ -76,6 +77,7 @@ nodePools:
   - customNodeLabels: []
     customNodeTaints: []
     disableHealthCheck: false
+    encryptionAtHost: false
     instanceType: Standard_D2s_v3
     name: md00
     replicas: 3


### PR DESCRIPTION
Towards https://github.com/giantswarm/wepa/issues/49

### Helper

* to disable the GH Action generating manifests diffs for installations, between target and source branches, comment the `/no_diffs_printing` on the PR.

### Trigger e2e tests

<!--
If for some reason you want to skip the e2e tests, remove the following lines.
-->

/run cluster-test-suites
