### PR TITLE
Use Standard_D4s_v5 for nodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.0.35] - 2024-02-07
+### Changed
 
+- Use `Standard_D4s_v5` for control plane and worker nodes.
+- Use 2 replicas for workers by default.
+
+## [0.0.35] - 2024-02-07
 
 ### Removed
 

--- a/examples/cluster-default/01_configmaps.yaml
+++ b/examples/cluster-default/01_configmaps.yaml
@@ -13,8 +13,8 @@ data:
 
     nodePools:
     - name: md00
-      instanceType: Standard_D2s_v5
-      replicas: 3
+      instanceType: Standard_D4s_v5
+      replicas: 2
       rootVolumeSizeGB: 50
 
 kind: ConfigMap

--- a/helm/cluster-azure/README.md
+++ b/helm/cluster-azure/README.md
@@ -62,7 +62,7 @@ Properties within the `.controlPlane` top-level object
 | `controlPlane.containerdVolumeSizeGB` | **Containerd volume size (GB)**|**Type:** `integer`<br/>**Default:** `100`|
 | `controlPlane.encryptionAtHost` | **Encryption at host** - Enable encryption at host for the control plane nodes.|**Type:** `boolean`<br/>**Default:** `false`|
 | `controlPlane.etcdVolumeSizeGB` | **Etcd volume size (GB)**|**Type:** `integer`<br/>**Default:** `100`|
-| `controlPlane.instanceType` | **Node VM size**|**Type:** `string`<br/>**Default:** `"Standard_D4s_v3"`|
+| `controlPlane.instanceType` | **Node VM size**|**Type:** `string`<br/>**Default:** `"Standard_D4s_v5"`|
 | `controlPlane.kubeletVolumeSizeGB` | **Kubelet volume size (GB)**|**Type:** `integer`<br/>**Default:** `100`|
 | `controlPlane.oidc` | **OIDC authentication**|**Type:** `object`<br/>|
 | `controlPlane.oidc.caPem` | **Certificate authority** - Identity provider's CA certificate in PEM format.|**Type:** `string`<br/>**Default:** `""`|

--- a/helm/cluster-azure/values.schema.json
+++ b/helm/cluster-azure/values.schema.json
@@ -633,7 +633,7 @@
                     "encryptionAtHost": false,
                     "instanceType": "Standard_D4s_v5",
                     "name": "md00",
-                    "replicas": 3,
+                    "replicas": 2,
                     "rootVolumeSizeGB": 50
                 }
             ]

--- a/helm/cluster-azure/values.schema.json
+++ b/helm/cluster-azure/values.schema.json
@@ -167,7 +167,7 @@
                 "instanceType": {
                     "type": "string",
                     "title": "Node VM size",
-                    "default": "Standard_D4s_v3"
+                    "default": "Standard_D4s_v5"
                 },
                 "kubeletVolumeSizeGB": {
                     "type": "integer",
@@ -631,7 +631,7 @@
                     "customNodeTaints": [],
                     "disableHealthCheck": false,
                     "encryptionAtHost": false,
-                    "instanceType": "Standard_D2s_v3",
+                    "instanceType": "Standard_D4s_v5",
                     "name": "md00",
                     "replicas": 3,
                     "rootVolumeSizeGB": 50

--- a/helm/cluster-azure/values.yaml
+++ b/helm/cluster-azure/values.yaml
@@ -20,7 +20,7 @@ controlPlane:
   containerdVolumeSizeGB: 100
   encryptionAtHost: false
   etcdVolumeSizeGB: 100
-  instanceType: Standard_D4s_v3
+  instanceType: Standard_D4s_v5
   kubeletVolumeSizeGB: 100
   oidc:
     caPem: ""
@@ -74,9 +74,9 @@ nodePools:
     customNodeTaints: []
     disableHealthCheck: false
     encryptionAtHost: false
-    instanceType: Standard_D2s_v3
+    instanceType: Standard_D4s_v5
     name: md00
-    replicas: 3
+    replicas: 2
     rootVolumeSizeGB: 50
 providerSpecific:
   azureClusterIdentity:


### PR DESCRIPTION
We updated these values in e2e tests https://github.com/giantswarm/cluster-test-suites/pull/218

I verified that 2 worker nodes (4CPU, 16GB RAM) are enough. 

Related thread: https://gigantic.slack.com/archives/C02HLSDH3DZ/p1707734730615589

### Trigger e2e tests

/run cluster-test-suites
