### PR TITLE
Adapt cleanup hook for cluster policies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Upgrade Flatcar image to [3510.2.5](https://www.flatcar.org/releases#release-3510.2.5)
 - Upgrade K8S version to `1.24.17`
 - Fix left-over azurefile-csi-driver helmreleases during cleanup.
+- Adapt cleanup hook for cluster policies.
 
 ## [0.0.31] - 2023-12-14
 

--- a/helm/cluster-azure/templates/helmreleases/cleanup-helmreleases-hook-job.yaml
+++ b/helm/cluster-azure/templates/helmreleases/cleanup-helmreleases-hook-job.yaml
@@ -108,6 +108,9 @@ spec:
       securityContext:
         runAsUser: 1000
         runAsGroup: 1000
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
       containers:
         - name: post-delete-job
           image: "{{ .Values.internal.kubectlImage.registry }}/{{ .Values.internal.kubectlImage.name }}:{{ .Values.internal.kubectlImage.tag }}"
@@ -120,6 +123,12 @@ spec:
                   kubectl patch -n {{ .Release.Namespace }} "${r}" --type=merge -p '{"metadata": {"finalizers": []}}'
               done
           securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            seccompProfile:
+              type: RuntimeDefault
             readOnlyRootFilesystem: true
           resources:
             requests:


### PR DESCRIPTION
This helm hook is supposed to clean-up leftovers when there is a race condition between helmcontroller and CAPI controllers. We sometimes need this hook. That is why e2e tests pass/fail randomly because of cluster deletion. This PR is supposed to fix the problem. 

I also observed leftover `HelmRelease` CRs and stuck org namespaces in our e2e MC. I cleaned them manually.

### Trigger e2e tests

<!--
If for some reason you want to skip the e2e tests, remove the following lines.
-->

/run cluster-test-suites
