### PR TITLE
additional tags for resource groups

### DIFF
--- a/helm/cluster-azure/README.md
+++ b/helm/cluster-azure/README.md
@@ -17,10 +17,8 @@ Properties within the `.providerSpecific` top-level object
 
 | **Property** | **Description** | **More Details** |
 | :----------- | :-------------- | :--------------- |
-| `providerSpecific.additionalResourceTags` | **Additional tags to be added to the resource group and to all resources in it**|**Type:** `array`<br/>**Default:** `[]`|
-| `providerSpecific.additionalResourceTags[*]` | **Tag definition**|**Type:** `object`<br/>|
-| `providerSpecific.additionalResourceTags[*].name` | **Tag name**|**Type:** `string`<br/>|
-| `providerSpecific.additionalResourceTags[*].value` | **Tag Value**|**Type:** `string`<br/>|
+| `providerSpecific.additionalResourceTags` | **Additional resource tags** - Additional tags to be added to the resource group and to all resources in it|**Type:** `object`<br/>**Default:** `{}`|
+| `providerSpecific.additionalResourceTags.*` | **Tag value** - Value of the tag|**Type:** `string`<br/>|
 | `providerSpecific.azureClusterIdentity` | **Identity** - AzureClusterIdentity resource to use for this cluster.|**Type:** `object`<br/>|
 | `providerSpecific.azureClusterIdentity.name` | **Name**|**Type:** `string`<br/>**Default:** `"cluster-identity"`|
 | `providerSpecific.azureClusterIdentity.namespace` | **Namespace**|**Type:** `string`<br/>**Default:** `"org-giantswarm"`|

--- a/helm/cluster-azure/README.md
+++ b/helm/cluster-azure/README.md
@@ -17,6 +17,10 @@ Properties within the `.providerSpecific` top-level object
 
 | **Property** | **Description** | **More Details** |
 | :----------- | :-------------- | :--------------- |
+| `providerSpecific.additionalResourceTags` | **Additional tags to be added to the resource group and to all resources in it**|**Type:** `array`<br/>**Default:** `[]`|
+| `providerSpecific.additionalResourceTags[*]` | **Tag definition**|**Type:** `object`<br/>|
+| `providerSpecific.additionalResourceTags[*].name` | **Tag name**|**Type:** `string`<br/>|
+| `providerSpecific.additionalResourceTags[*].value` | **Tag Value**|**Type:** `string`<br/>|
 | `providerSpecific.azureClusterIdentity` | **Identity** - AzureClusterIdentity resource to use for this cluster.|**Type:** `object`<br/>|
 | `providerSpecific.azureClusterIdentity.name` | **Name**|**Type:** `string`<br/>**Default:** `"cluster-identity"`|
 | `providerSpecific.azureClusterIdentity.namespace` | **Namespace**|**Type:** `string`<br/>**Default:** `"org-giantswarm"`|

--- a/helm/cluster-azure/README.md
+++ b/helm/cluster-azure/README.md
@@ -17,7 +17,7 @@ Properties within the `.providerSpecific` top-level object
 
 | **Property** | **Description** | **More Details** |
 | :----------- | :-------------- | :--------------- |
-| `providerSpecific.additionalResourceTags` | **Additional resource tags** - Additional tags to be added to the resource group and to all resources in it|**Type:** `object`<br/>**Default:** `{}`|
+| `providerSpecific.additionalResourceTags` | **Additional resource tags** - Additional tags to be added to the resource group and to all resources in it.|**Type:** `object`<br/>**Default:** `{}`|
 | `providerSpecific.additionalResourceTags.*` | **Tag value** - Value of the tag|**Type:** `string`<br/>|
 | `providerSpecific.azureClusterIdentity` | **Identity** - AzureClusterIdentity resource to use for this cluster.|**Type:** `object`<br/>|
 | `providerSpecific.azureClusterIdentity.name` | **Name**|**Type:** `string`<br/>**Default:** `"cluster-identity"`|

--- a/helm/cluster-azure/templates/_additional_tags.tpl
+++ b/helm/cluster-azure/templates/_additional_tags.tpl
@@ -1,0 +1,9 @@
+{{- define "additional-tags" -}}
+{{- $tags := .tags | default list }}
+{{- if gt (len $tags) 0 }}
+additionalTags:
+  {{- range $tag := $tags }}
+  {{ $tag.name }}: {{ $tag.value | quote -}}
+  {{- end -}}
+{{- end -}}
+{{- end -}}

--- a/helm/cluster-azure/templates/_additional_tags.tpl
+++ b/helm/cluster-azure/templates/_additional_tags.tpl
@@ -1,9 +1,7 @@
 {{- define "additional-tags" -}}
-{{- $tags := .tags | default list }}
-{{- if gt (len $tags) 0 }}
+{{- $tags := .tags | default dict }}
+{{- if $tags }}
 additionalTags:
-  {{- range $tag := $tags }}
-  {{ $tag.name }}: {{ $tag.value | quote -}}
-  {{- end -}}
+  {{- toYaml $tags | nindent 2 }}
 {{- end -}}
 {{- end -}}

--- a/helm/cluster-azure/templates/_azure_cluster.tpl
+++ b/helm/cluster-azure/templates/_azure_cluster.tpl
@@ -7,6 +7,7 @@ metadata:
   name: {{ include "resource.default.name" $ }}
   namespace: {{ .Release.Namespace }}
 spec:
+  {{- include "additional-tags" (dict "tags" .Values.providerSpecific.additionalResourceTags) | indent 2}}
   identityRef:
     apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
     kind: AzureClusterIdentity

--- a/helm/cluster-azure/values.schema.json
+++ b/helm/cluster-azure/values.schema.json
@@ -850,27 +850,23 @@
             ],
             "properties": {
                 "additionalResourceTags": {
-                    "type": "array",
-                    "title": "Additional tags to be added to the resource group and to all resources in it",
-                    "items": {
-                        "type": "object",
-                        "title": "Tag definition",
-                        "required": [
-                            "name",
-                            "value"
-                        ],
-                        "properties": {
-                            "name": {
-                                "type": "string",
-                                "title": "Tag name"
-                            },
-                            "value": {
-                                "type": "string",
-                                "title": "Tag Value"
-                            }
-                        }
+                    "type": "object",
+                    "title": "Additional resource tags",
+                    "description": "Additional tags to be added to the resource group and to all resources in it.",
+                    "additionalProperties": {
+                        "type": "string",
+                        "title": "Tag value",
+                        "description": "Value of the tag",
+                        "maxLength": 256
                     },
-                    "default": []
+                    "default": {},
+                    "propertyNames": {
+                        "type": "string",
+                        "title": "Tag name",
+                        "description": "Name of the tag",
+                        "maxLength": 128,
+                        "pattern": "^[^<>%&?/\\\\]*$"
+                    }
                 },
                 "azureClusterIdentity": {
                     "type": "object",

--- a/helm/cluster-azure/values.schema.json
+++ b/helm/cluster-azure/values.schema.json
@@ -849,6 +849,29 @@
                 "subscriptionId"
             ],
             "properties": {
+                "additionalResourceTags": {
+                    "type": "array",
+                    "title": "Additional tags to be added to the resource group and to all resources in it",
+                    "items": {
+                        "type": "object",
+                        "title": "Tag definition",
+                        "required": [
+                            "name",
+                            "value"
+                        ],
+                        "properties": {
+                            "name": {
+                                "type": "string",
+                                "title": "Tag name"
+                            },
+                            "value": {
+                                "type": "string",
+                                "title": "Tag Value"
+                            }
+                        }
+                    },
+                    "default": []
+                },
                 "azureClusterIdentity": {
                     "type": "object",
                     "title": "Identity",

--- a/helm/cluster-azure/values.yaml
+++ b/helm/cluster-azure/values.yaml
@@ -81,6 +81,7 @@ nodePools:
     replicas: 2
     rootVolumeSizeGB: 50
 providerSpecific:
+  additionalResourceTags: []
   azureClusterIdentity:
     name: cluster-identity
     namespace: org-giantswarm

--- a/helm/cluster-azure/values.yaml
+++ b/helm/cluster-azure/values.yaml
@@ -81,7 +81,7 @@ nodePools:
     replicas: 2
     rootVolumeSizeGB: 50
 providerSpecific:
-  additionalResourceTags: []
+  additionalResourceTags: {}
   azureClusterIdentity:
     name: cluster-identity
     namespace: org-giantswarm


### PR DESCRIPTION
Towards: https://github.com/giantswarm/roadmap/issues/3329

Expose `awscluster.spec.additionalTags` to helm values to allow setting custom tags to the resource group of a cluster and to all resources within the group

### Please check if PR meets these requirements

- [ ] Results of the diffs have been examined and no unintended changes are being introduced.

### Helper

* to disable the GH Action generating manifests diffs for installations, between target and source branches, comment the `/no_diffs_printing` on the PR.

### Trigger e2e tests

<!--
If for some reason you want to skip the e2e tests, remove the following lines.
-->

/run cluster-test-suites
