### PR TITLE
Add default tag `giantswarm-cluster` to all resources.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Add default tag `giantswarm.io/cluster` to all resources.
+- Add default tag `giantswarm-cluster` to all resources.
 
 ## [0.4.0] - 2024-03-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add default tag `giantswarm.io/cluster` to all resources.
+
 ## [0.4.0] - 2024-03-26
 
 ### Added

--- a/helm/cluster-azure/templates/_additional_tags.tpl
+++ b/helm/cluster-azure/templates/_additional_tags.tpl
@@ -1,7 +1,7 @@
 {{- define "additional-tags" -}}
 {{- $tags := .Values.providerSpecific.additionalResourceTags | default dict }}
 additionalTags:
-  giantswarm.io/cluster: {{ include "resource.default.name" . }}
+  giantswarm-cluster: {{ include "resource.default.name" . }}
   {{- if $tags }}
   {{- toYaml $tags | nindent 2 }}
   {{- end -}}

--- a/helm/cluster-azure/templates/_additional_tags.tpl
+++ b/helm/cluster-azure/templates/_additional_tags.tpl
@@ -1,7 +1,8 @@
 {{- define "additional-tags" -}}
-{{- $tags := .tags | default dict }}
-{{- if $tags }}
+{{- $tags := .Values.providerSpecific.additionalResourceTags | default dict }}
 additionalTags:
+  giantswarm.io/cluster: {{ include "resource.default.name" . }}
+  {{- if $tags }}
   {{- toYaml $tags | nindent 2 }}
-{{- end -}}
+  {{- end -}}
 {{- end -}}

--- a/helm/cluster-azure/templates/_azure_cluster.tpl
+++ b/helm/cluster-azure/templates/_azure_cluster.tpl
@@ -7,7 +7,7 @@ metadata:
   name: {{ include "resource.default.name" $ }}
   namespace: {{ .Release.Namespace }}
 spec:
-  {{- include "additional-tags" (dict "tags" .Values.providerSpecific.additionalResourceTags) | indent 2}}
+  {{- include "additional-tags" . | indent 2}}
   identityRef:
     apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
     kind: AzureClusterIdentity


### PR DESCRIPTION
Part of: https://github.com/giantswarm/roadmap/issues/3329

This PR adds a default tag `giantswarm-cluster` to all resources in the cluster.

### Please check if PR meets these requirements

- [ ] Results of the diffs have been examined and no unintended changes are being introduced.

### Helper

* to disable the GH Action generating manifests diffs for installations, between target and source branches, comment the `/no_diffs_printing` on the PR.

### Trigger e2e tests

<!--
If for some reason you want to skip the e2e tests, remove the following lines.
-->

/run cluster-test-suites
