### PR TITLE
Update teleport node labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Update teleport node labels - add `ins=` label and remove `cluster=` label condition check, such that MC nodes have this label.
+
 ## [0.5.0] - 2024-03-26
 
 ### Added

--- a/helm/cluster-azure/files/etc/teleport.yaml
+++ b/helm/cluster-azure/files/etc/teleport.yaml
@@ -27,11 +27,9 @@ ssh_service:
     command: [/opt/teleport-node-role.sh]
     period: 1m0s
   labels:
+    ins: {{ .Values.managementCluster }}
     mc: {{ .Values.managementCluster }}
-    {{- $clusterName := include "resource.default.name" $ }}
-    {{- if ne .Values.managementCluster $clusterName }}
     cluster: {{ include "resource.default.name" $ }}
-    {{- end }}
     baseDomain: {{ .Values.baseDomain }}
 proxy_service:
   enabled: "no"


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/30398

### What does this PR do?
- Add new `ins=` label to all nodes, same value as mc= label
- Removes conditional check for `cluster=` label for MC nodes

### Any background context you can provide?

Currently, our labels doesn't support listing only MC nodes, because cluster= label is not present on MC nodes, only WC nodes and mc= label is common on all nodes.

In Web UI, we can filter by setting cluster="" but same doesn't work on Terminal tsh client.

```
$ tsh ssh root@mc=gazelle,cluster=
ERROR: invalid label spec: 'mc=gazelle,cluster=', should be 'key=value'

$ tsh ssh root@mc=gazelle,cluster=""
ERROR: invalid label spec: 'mc=gazelle,cluster=', should be 'key=value'
```

### Please check if PR meets these requirements

- [ ] Results of the diffs have been examined and no unintended changes are being introduced.

### Helper

* to disable the GH Action generating manifests diffs for installations, between target and source branches, comment the `/no_diffs_printing` on the PR.

### Trigger e2e tests

<!--
If for some reason you want to skip the e2e tests, remove the following lines.
-->

/run cluster-test-suites
