### PR TITLE
Bump cluster version to fix IP problem during node startup

### DIFF
--- a/.circleci/ct-config.yaml
+++ b/.circleci/ct-config.yaml
@@ -1,3 +1,4 @@
 ---
 chart-repos:
   - cluster-catalog=https://giantswarm.github.io/cluster-catalog
+  - cluster-test-catalog=https://giantswarm.github.io/cluster-test-catalog

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Update `cluster` chart version to fix `unable to select an IP from default routes` problem during node startup.
+
 ## [0.11.0] - 2024-05-28
 
 ### Changed

--- a/helm/cluster-azure/Chart.lock
+++ b/helm/cluster-azure/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: cluster
-  repository: https://giantswarm.github.io/cluster-catalog
-  version: 0.27.0
+  repository: https://giantswarm.github.io/cluster-test-catalog
+  version: 0.27.0-f26ba6380b830d00920cee9d582946651cd00e4e
 - name: cluster-shared
   repository: https://giantswarm.github.io/cluster-catalog
   version: 0.7.0
-digest: sha256:66b207b72e69809bb09f2ae5361030cccaba6fe19a15e6108da0de74a6ecaca4
-generated: "2024-05-28T12:45:14.440976+02:00"
+digest: sha256:1c1956a514ae5f6132c264ad1475d7a4044a761a9f71c1de77256c106a177a8c
+generated: "2024-05-29T15:43:14.80968+03:00"

--- a/helm/cluster-azure/Chart.yaml
+++ b/helm/cluster-azure/Chart.yaml
@@ -12,8 +12,8 @@ annotations:
   application.giantswarm.io/app-type: "cluster"
 dependencies:
 - name: cluster
-  version: "0.27.0"
-  repository: "https://giantswarm.github.io/cluster-catalog"
+  version: "0.27.0-f26ba6380b830d00920cee9d582946651cd00e4e"
+  repository: "https://giantswarm.github.io/cluster-test-catalog"
 - name: cluster-shared
   version: "0.7.0"
   repository: "https://giantswarm.github.io/cluster-catalog"


### PR DESCRIPTION
We observe `unable to select an IP from default routes` in kubeadm logs during node startup. 

We have  `After=network.target` in `/etc/systemd/system/kubeadm.service` but it seems it doesn't guarantee that the network will be online during kubeadm service.

In https://github.com/giantswarm/cluster/pull/204, we added `network-online` as dependency for kubeadm. See the doc https://www.freedesktop.org/wiki/Software/systemd/NetworkTarget/


/run cluster-test-suites
