### PR TITLE
Move to .Values.managementCluster to .Values.global

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Use `.Values.global.managementCluster` for teleport node labels.
+
 ## [0.14.1] - 2024-06-21
 
 ### Added

--- a/helm/cluster-azure/files/etc/teleport.yaml
+++ b/helm/cluster-azure/files/etc/teleport.yaml
@@ -27,8 +27,8 @@ ssh_service:
     command: [/opt/teleport-node-role.sh]
     period: 1m0s
   labels:
-    ins: {{ .Values.managementCluster }}
-    mc: {{ .Values.managementCluster }}
+    ins: {{ .Values.global.managementCluster }}
+    mc: {{ .Values.global.managementCluster }}
     cluster: {{ include "resource.default.name" $ }}
     baseDomain: {{ .Values.global.connectivity.baseDomain }}
 proxy_service:


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/31129 

Attempt to fix issues where the teleport label in SSH nodes have missing `mc:` and `ins:` label after node roll.

Encountered in `wacker/whale` MC.

![Screenshot 2024-06-24 at 7 49 35 PM](https://github.com/giantswarm/cluster-azure/assets/5674762/ba189967-d6ef-4cb1-bd6a-adbdc499c998)


### Please check if PR meets these requirements

- [ ] Results of the diffs have been examined and no unintended changes are being introduced.

### Helper

* to disable the GH Action generating manifests diffs for installations, between target and source branches, comment the `/no_diffs_printing` on the PR.

### Trigger e2e tests

<!--
If for some reason you want to skip the e2e tests, remove the following lines.

Note: Tests are not automatically executed when creating a draft PR
If you do want to trigger the tests while still in draft then please add a comment with the trigger.
-->

/run cluster-test-suites
