### PR TITLE
Append cluster name to natgateway names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### **Breaking change**
+
+- Append cluster name to `natgateway` resource to differentiate CR names for `azure-service-operator`.
+
 ### Changed
 
 - Add `allowedSubscriptions` parameter for multi-subscription use case.
-
+  
 ### Fixed
 
 - Use correct context at `MachineDeployment` helper.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Add `allowedSubscriptions` parameter for multi-subscription use case.
-  
+
 ### Fixed
 
 - Use correct context at `MachineDeployment` helper.

--- a/helm/cluster-azure/templates/_helpers.tpl
+++ b/helm/cluster-azure/templates/_helpers.tpl
@@ -328,7 +328,7 @@ node-subnet
 {{- if hasKey $.Values.global.connectivity.network.workers "natGatewayName" -}}
 {{ $.Values.global.connectivity.network.workers.natGatewayName }}
 {{- else -}}
-node-natgateway
+{{ include "resource.default.name" $ }}-node-natgateway
 {{- end -}}
 {{- end -}}
 


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/3294

***Why do we need this breaking change?***
We will deploy `azure-service-operator` as part of CAPZ soon and `NatGateway` names have to be unique in each namespace. 

https://kubernetes.slack.com/archives/CEX9HENG7/p1720180477056679
 
### Trigger e2e tests

/run cluster-test-suites
