### PR TITLE
Respect global.apps configuration for external-dns-private

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed 
+
+- Respect `global.apps.externalDnsPrivate` to overwrite configuration of `external-dns-private` app.
+
 ## [0.16.0] - 2024-07-10
 
 ### **Breaking change**

--- a/helm/cluster-azure/templates/_externaldnsprivate_app_config.yaml
+++ b/helm/cluster-azure/templates/_externaldnsprivate_app_config.yaml
@@ -1,0 +1,22 @@
+{{/* Azure-specific external-dns-private Helm values*/}}
+{{/* https://github.com/giantswarm/external-dns-app/blob/main/helm/external-dns-app/values.yaml*/}}
+{{- define "azureExternalDnsPrivateHelmValues" }}
+provider: azure-private-dns
+clusterID: {{ include "resource.default.name" $ }}
+crd:
+  install: false
+domainFilters:
+  - "{{ include "resource.default.name" $ }}.{{ .Values.global.connectivity.baseDomain }}"
+txtOwnerId: giantswarm-io-external-dns
+txtPrefix: {{ include "resource.default.name" $ }}
+sources:
+  - service
+extraVolumes:
+  - name: azure-config-file
+    hostPath:
+      path: /etc/kubernetes
+extraVolumeMounts:
+  - name: azure-config-file
+    mountPath: /etc/kubernetes
+    readOnly: true
+{{- end }}

--- a/helm/cluster-azure/templates/externaldns_private_app.yaml
+++ b/helm/cluster-azure/templates/externaldns_private_app.yaml
@@ -8,25 +8,18 @@ metadata:
   labels:
     {{- include "labels.common" . | nindent 4 }}
 data:
+    {{- $appHelmValues := (include "azureExternalDnsPrivateHelmValues" $)| fromYaml -}}
+    {{- $userConfig := dict }}
+    {{- $userConfigRaw := get $.Values.global.apps "externalDnsPrivate" }}
+    {{- if $userConfigRaw }}
+    {{- $userConfig = $userConfigRaw | toYaml | toString | fromYaml }}
+    {{- end }}
+    {{- if $userConfig.values }}
+    {{- $appHelmValues = mergeOverwrite $appHelmValues (deepCopy $userConfig.values) -}}
+    {{- end }}
   values: |
-    provider: azure-private-dns
-    clusterID: {{ include "resource.default.name" $ }}
-    crd:
-      install: false
-    domainFilters:
-      - "{{ include "resource.default.name" $ }}.{{ .Values.global.connectivity.baseDomain }}"
-    txtOwnerId: giantswarm-io-external-dns
-    txtPrefix: {{ include "resource.default.name" $ }}
-    sources:
-      - service
-    extraVolumes:
-      - name: azure-config-file
-        hostPath:
-          path: /etc/kubernetes
-    extraVolumeMounts:
-      - name: azure-config-file
-        mountPath: /etc/kubernetes
-        readOnly: true
+    {{- $appHelmValues | toYaml | nindent 4 }}
+
 ---
 apiVersion: application.giantswarm.io/v1alpha1
 kind: App


### PR DESCRIPTION
We don't respect `global.apps.externalDnsPrivate.values` and it is a bug. With this PR, we will overwrite default configuration with it.

### Trigger e2e tests

<!--
If for some reason you want to skip the e2e tests, remove the following lines.

Note: Tests are not automatically executed when creating a draft PR
If you do want to trigger the tests while still in draft then please add a comment with the trigger.
-->

/run cluster-test-suites
