### PR TITLE
Test cluster chart PR #260

### DIFF
--- a/helm/cluster-azure/Chart.lock
+++ b/helm/cluster-azure/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: cluster
-  repository: https://giantswarm.github.io/cluster-catalog
-  version: 0.32.0
+  repository: https://giantswarm.github.io/cluster-test-catalog
+  version: 0.35.0-13d15a5bcd0772dedd8d09eb2b2a917a119c3949
 - name: cluster-shared
   repository: https://giantswarm.github.io/cluster-catalog
   version: 0.7.1
-digest: sha256:f8812d215afa70a9a93275ab0e3b9993078ff83315fac6785cc024a417a93e0b
-generated: "2024-06-19T09:48:18.058412+02:00"
+digest: sha256:fa17ead07dcd7e7d2702f8754267604156dee24b847d3e35e0807924e2d0ffbd
+generated: "2024-07-16T14:56:45.961478+02:00"

--- a/helm/cluster-azure/Chart.yaml
+++ b/helm/cluster-azure/Chart.yaml
@@ -12,8 +12,8 @@ annotations:
   application.giantswarm.io/app-type: "cluster"
 dependencies:
 - name: cluster
-  version: "0.32.0"
-  repository: "https://giantswarm.github.io/cluster-catalog"
+  version: "0.35.0-13d15a5bcd0772dedd8d09eb2b2a917a119c3949"
+  repository: https://giantswarm.github.io/cluster-test-catalog
 - name: cluster-shared
   version: "0.7.1"
   repository: "https://giantswarm.github.io/cluster-catalog"

--- a/helm/cluster-azure/README.md
+++ b/helm/cluster-azure/README.md
@@ -238,7 +238,7 @@ Advanced configuration of components that are running on all nodes.
 | **Property** | **Description** | **More Details** |
 | :----------- | :-------------- | :--------------- |
 | `global.components.containerd` | **Containerd** - Configuration of containerd.|**Type:** `object`<br/>|
-| `global.components.containerd.containerRegistries` | **Container registries** - Endpoints and credentials configuration for container registries.|**Type:** `object`<br/>**Default:** `{"docker.io":[{"endpoint":"registry-1.docker.io"},{"endpoint":"giantswarm.azurecr.io"}]}`|
+| `global.components.containerd.containerRegistries` | **Container registries** - Endpoints and credentials configuration for container registries.|**Type:** `object`<br/>**Default:** `{"docker.io":[{"endpoint":"registry-1.docker.io"},{"endpoint":"giantswarm.azurecr.io"}],"gsoci.azurecr.io":[{"endpoint":"gsoci.azurecr.io"}]}`|
 | `global.components.containerd.containerRegistries.*` | **Registries** - Container registries and mirrors|**Type:** `array`<br/>|
 | `global.components.containerd.containerRegistries.*[*]` | **Registry**|**Type:** `object`<br/>|
 | `global.components.containerd.containerRegistries.*[*].credentials` | **Credentials**|**Type:** `object`<br/>|
@@ -252,6 +252,10 @@ Advanced configuration of components that are running on all nodes.
 | `global.components.containerd.localRegistryCache.mirroredRegistries` | **Registries to cache locally** - A list of registries that should be cached.|**Type:** `array`<br/>**Default:** `[]`|
 | `global.components.containerd.localRegistryCache.mirroredRegistries[*]` |**None**|**Type:** `string`<br/>|
 | `global.components.containerd.localRegistryCache.port` | **Local port for the registry cache** - Port for the local registry cache under: http://127.0.0.1:<PORT>.|**Type:** `integer`<br/>**Default:** `32767`|
+| `global.components.containerd.managementClusterRegistryCache` | **Management cluster registry cache** - Caching container registry on a management cluster level.|**Type:** `object`<br/>|
+| `global.components.containerd.managementClusterRegistryCache.enabled` | **Enabled** - Enabling this will configure containerd to use management cluster's Zot registry service. To make use of it as a pull-through cache, you also have to specify registries to cache images for.|**Type:** `boolean`<br/>**Default:** `true`|
+| `global.components.containerd.managementClusterRegistryCache.mirroredRegistries` | **Registries to cache** - Here you must specify each registry to cache container images for. Please also make sure to have an entry for each registry in Global > Components > Containerd > Container registries.|**Type:** `array`<br/>**Default:** `["gsoci.azurecr.io"]`|
+| `global.components.containerd.managementClusterRegistryCache.mirroredRegistries[*]` |**None**|**Type:** `string`<br/>|
 
 ### Connectivity
 Properties within the `.global.connectivity` object

--- a/helm/cluster-azure/values.schema.json
+++ b/helm/cluster-azure/values.schema.json
@@ -697,6 +697,11 @@
                                             {
                                                 "endpoint": "giantswarm.azurecr.io"
                                             }
+                                        ],
+                                        "gsoci.azurecr.io": [
+                                            {
+                                                "endpoint": "gsoci.azurecr.io"
+                                            }
                                         ]
                                     }
                                 },
@@ -730,6 +735,34 @@
                                             "title": "Local port for the registry cache",
                                             "description": "Port for the local registry cache under: http://127.0.0.1:<PORT>.",
                                             "default": 32767
+                                        }
+                                    }
+                                },
+                                "managementClusterRegistryCache": {
+                                    "type": "object",
+                                    "title": "Management cluster registry cache",
+                                    "description": "Caching container registry on a management cluster level.",
+                                    "required": [
+                                        "enabled"
+                                    ],
+                                    "additionalProperties": false,
+                                    "properties": {
+                                        "enabled": {
+                                            "type": "boolean",
+                                            "title": "Enabled",
+                                            "description": "Enabling this will configure containerd to use management cluster's Zot registry service. To make use of it as a pull-through cache, you also have to specify registries to cache images for.",
+                                            "default": true
+                                        },
+                                        "mirroredRegistries": {
+                                            "type": "array",
+                                            "title": "Registries to cache",
+                                            "description": "Here you must specify each registry to cache container images for. Please also make sure to have an entry for each registry in Global > Components > Containerd > Container registries.",
+                                            "items": {
+                                                "type": "string"
+                                            },
+                                            "default": [
+                                                "gsoci.azurecr.io"
+                                            ]
                                         }
                                     }
                                 }

--- a/helm/cluster-azure/values.yaml
+++ b/helm/cluster-azure/values.yaml
@@ -203,10 +203,16 @@ global:
         docker.io:
           - endpoint: registry-1.docker.io
           - endpoint: giantswarm.azurecr.io
+        gsoci.azurecr.io:
+          - endpoint: gsoci.azurecr.io
       localRegistryCache:
         enabled: false
         mirroredRegistries: []
         port: 32767
+      managementClusterRegistryCache:
+        enabled: true
+        mirroredRegistries:
+          - gsoci.azurecr.io
   connectivity:
     allowedCIDRs: []
     baseDomain: azuretest.gigantic.io


### PR DESCRIPTION
### Changes

Update the cluster chart version from `0.35.0` to `0.35.0-cc06b2331eb0c71139ac4eec1d743a2834fb3161` in order to test cluster chart pull request https://github.com/giantswarm/cluster/pull/260.

Cluster chart pull request title: `Use MC Zot as registry mirror by default in all workload clusters`.


### Please check if PR meets these requirements

- [ ] Results of the diffs have been examined and no unintended changes are being introduced.

### Helper

* to disable the GH Action generating manifests diffs for installations, between target and source branches, comment the `/no_diffs_printing` on the PR.

### Trigger e2e tests

<!--
If for some reason you want to skip the e2e tests, remove the following lines.

Note: Tests are not automatically executed when creating a draft PR
If you do want to trigger the tests while still in draft then please add a comment with the trigger.
-->

/run cluster-test-suites
