### PR TITLE
Apps: Use `catalog` from Release CR.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Apps: Use `catalog` from Release CR.
+
 ## [1.0.0] - 2024-08-12
 
 > [!IMPORTANT]

--- a/helm/cluster-azure/templates/azure-cloud-controller-manager-helmrelease.yaml
+++ b/helm/cluster-azure/templates/azure-cloud-controller-manager-helmrelease.yaml
@@ -35,11 +35,10 @@ spec:
     spec:
       chart: azure-cloud-controller-manager-app
       {{- $_ := set $ "appName" "azure-cloud-controller-manager" }}
-      {{- $appVersion := include "cluster.app.version" $ }}
-      version: {{ $appVersion }}
+      version: {{ include "cluster.app.version" $ }}
       sourceRef:
         kind: HelmRepository
-        name: {{ include "resource.default.name" $ }}-default
+        name: {{ include "resource.default.name" $ }}-{{ include "cluster.app.catalog" $ }}
   kubeConfig:
     secretRef:
       name: {{ include "resource.default.name" $ }}-kubeconfig

--- a/helm/cluster-azure/templates/azure-cloud-node-manager-helmrelease.yaml
+++ b/helm/cluster-azure/templates/azure-cloud-node-manager-helmrelease.yaml
@@ -31,11 +31,10 @@ spec:
     spec:
       chart: azure-cloud-node-manager-app
       {{- $_ := set $ "appName" "azure-cloud-node-manager" }}
-      {{- $appVersion := include "cluster.app.version" $ }}
-      version: {{ $appVersion }}
+      version: {{ include "cluster.app.version" $ }}
       sourceRef:
         kind: HelmRepository
-        name: {{ include "resource.default.name" $ }}-default
+        name: {{ include "resource.default.name" $ }}-{{ include "cluster.app.catalog" $ }}
   kubeConfig:
     secretRef:
       name: {{ include "resource.default.name" $ }}-kubeconfig

--- a/helm/cluster-azure/templates/azuredisk-csi-driver-helmrelease.yaml
+++ b/helm/cluster-azure/templates/azuredisk-csi-driver-helmrelease.yaml
@@ -39,11 +39,10 @@ spec:
     spec:
       chart: azuredisk-csi-driver-app
       {{- $_ := set $ "appName" "azuredisk-csi-driver" }}
-      {{- $appVersion := include "cluster.app.version" $ }}
-      version: {{ $appVersion }}
+      version: {{ include "cluster.app.version" $ }}
       sourceRef:
         kind: HelmRepository
-        name: {{ include "resource.default.name" $ }}-default
+        name: {{ include "resource.default.name" $ }}-{{ include "cluster.app.catalog" $ }}
   kubeConfig:
     secretRef:
       name: {{ include "resource.default.name" $ }}-kubeconfig

--- a/helm/cluster-azure/templates/azurefile-csi-driver-helmrelease.yaml
+++ b/helm/cluster-azure/templates/azurefile-csi-driver-helmrelease.yaml
@@ -28,11 +28,10 @@ spec:
     spec:
       chart: azurefile-csi-driver-app
       {{- $_ := set $ "appName" "azurefile-csi-driver" }}
-      {{- $appVersion := include "cluster.app.version" $ }}
-      version: {{ $appVersion }}
+      version: {{ include "cluster.app.version" $ }}
       sourceRef:
         kind: HelmRepository
-        name: {{ include "resource.default.name" $ }}-default
+        name: {{ include "resource.default.name" $ }}-{{ include "cluster.app.catalog" $ }}
   kubeConfig:
     secretRef:
       name: {{ include "resource.default.name" $ }}-kubeconfig

--- a/helm/cluster-azure/templates/externaldns_private_app.yaml
+++ b/helm/cluster-azure/templates/externaldns_private_app.yaml
@@ -30,11 +30,10 @@ metadata:
     {{- include "labels.common" . | nindent 4 }}
     giantswarm.io/managed-by: {{ .Chart.Name }}
 spec:
-  catalog: default
-  name: external-dns-app
   {{- $_ := set $ "appName" "external-dns" }}
-  {{- $appVersion := include "cluster.app.version" $ }}
-  version: {{ $appVersion }}
+  catalog: {{ include "cluster.app.catalog" $ }}
+  name: external-dns-app
+  version: {{ include "cluster.app.version" $ }}
   namespace: kube-system
   config:
     configMap:


### PR DESCRIPTION
### What this PR does / why we need it

This PR aligns the way we define the catalog of an app to the way we do it in the `cluster` chart and therefore allows setting a different catalog in the Release CR, which is sometimes required for testing apps during development, e.g. by setting `catalog: default-test`.

I came across this issue when forging CAPZ v29.0.0, where I also needed to bump the cloud provider apps.

This is basically the same change as in https://github.com/giantswarm/cluster-aws/pull/794.

### Checklist

- [x] Updated CHANGELOG.md.

### Trigger E2E tests

<!--
If you want to skip the E2E tests, remove the following line and add the `skip/ci` label to skip the check.

Note: Tests are not automatically executed when creating a draft PR. If you do want to trigger the tests while still in draft then please add a comment with the trigger.
-->

/run cluster-test-suites

<!-- If you want to disable Helm template rendering diffs as GitHub comment, uncomment this (command must be on its own line): -->

<!-- /no_diffs_printing -->
