### PR TITLE
Remove kubectlImage and kubernetesVersion from internal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Chart: Update `cluster` to [v1.2.2](https://github.com/giantswarm/cluster/releases/tag/v1.2.2)
+  - Set `MachineDeployment` Kubernetes version from release
+
+### Removed
+
+- Remove unused `internal` values from `values.schema.json`.
+
 ## [1.1.0] - 2024-08-29
 
 ### Changed

--- a/helm/cluster-azure/Chart.lock
+++ b/helm/cluster-azure/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: cluster
-  repository: https://giantswarm.github.io/cluster-test-catalog
-  version: 1.2.1-5bc22c95b25e6339710321ef736e190047680b8d
+  repository: https://giantswarm.github.io/cluster-catalog
+  version: 1.2.2
 - name: cluster-shared
   repository: https://giantswarm.github.io/cluster-catalog
   version: 0.7.1
-digest: sha256:6e47ace995ed60654718ad0ff7cb05b9bdc884544bebfe5432b838c144ce0a61
-generated: "2024-09-05T18:53:59.554641+02:00"
+digest: sha256:43e0a2e7332a7b5938e13da32cd7cb866ca05e481cef7b898698ad50e1e76c7b
+generated: "2024-09-05T19:39:26.2953+02:00"

--- a/helm/cluster-azure/Chart.lock
+++ b/helm/cluster-azure/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: cluster
-  repository: https://giantswarm.github.io/cluster-catalog
-  version: 1.2.1
+  repository: https://giantswarm.github.io/cluster-test-catalog
+  version: 1.2.1-5bc22c95b25e6339710321ef736e190047680b8d
 - name: cluster-shared
   repository: https://giantswarm.github.io/cluster-catalog
   version: 0.7.1
-digest: sha256:ee84a487ece1fd36ba99f3faea08212dbf0ca09f0d6c7f979f0edd41dcedf3e1
-generated: "2024-08-20T13:33:05.539029517Z"
+digest: sha256:6e47ace995ed60654718ad0ff7cb05b9bdc884544bebfe5432b838c144ce0a61
+generated: "2024-09-05T18:53:59.554641+02:00"

--- a/helm/cluster-azure/Chart.yaml
+++ b/helm/cluster-azure/Chart.yaml
@@ -12,8 +12,8 @@ annotations:
   application.giantswarm.io/team: phoenix
 dependencies:
   - name: cluster
-    version: "1.2.1-5bc22c95b25e6339710321ef736e190047680b8d"
-    repository: https://giantswarm.github.io/cluster-test-catalog
+    version: "1.2.2"
+    repository: https://giantswarm.github.io/cluster-catalog
   - name: cluster-shared
     version: "0.7.1"
     repository: https://giantswarm.github.io/cluster-catalog

--- a/helm/cluster-azure/Chart.yaml
+++ b/helm/cluster-azure/Chart.yaml
@@ -12,8 +12,8 @@ annotations:
   application.giantswarm.io/team: phoenix
 dependencies:
   - name: cluster
-    version: "1.2.1"
-    repository: https://giantswarm.github.io/cluster-catalog
+    version: "1.2.1-5bc22c95b25e6339710321ef736e190047680b8d"
+    repository: https://giantswarm.github.io/cluster-test-catalog
   - name: cluster-shared
     version: "0.7.1"
     repository: https://giantswarm.github.io/cluster-catalog

--- a/helm/cluster-azure/README.md
+++ b/helm/cluster-azure/README.md
@@ -361,11 +361,6 @@ Properties within the `.internal` top-level object
 | `internal.defaults.softEvictionGracePeriod` | **Default settings for soft eviction grace period**|**Type:** `string`<br/>**Default:** `"memory.available=30s,nodefs.available=2m,nodefs.inodesFree=1m,imagefs.available=2m,pid.available=1m"`|
 | `internal.defaults.softEvictionThresholds` | **Default settings for soft eviction thresholds**|**Type:** `string`<br/>**Default:** `"memory.available\u003c500Mi,nodefs.available\u003c15%,nodefs.inodesFree\u003c5%,imagefs.available\u003c15%,pid.available\u003c30%"`|
 | `internal.enableVpaResources` | **Enable VPA Resources in helmreleases**|**Type:** `boolean`<br/>**Default:** `true`|
-| `internal.kubectlImage` | **Kubectl Image settings**|**Type:** `object`<br/>|
-| `internal.kubectlImage.name` | **Image name** - Name of the image Registry|**Type:** `string`<br/>**Default:** `"giantswarm/kubectl"`|
-| `internal.kubectlImage.registry` | **Kubectl Image Registry** - Registry for the kubectl image|**Type:** `string`<br/>**Default:** `"gsoci.azurecr.io"`|
-| `internal.kubectlImage.tag` | **Image tag**|**Type:** `string`<br/>**Default:** `"1.25.15"`|
-| `internal.kubernetesVersion` | **Kubernetes version**|**Type:** `string`<br/>**Default:** `"1.25.16"`|
 | `internal.network` | **Network configuration** - Internal network configuration that is susceptible to more frequent change|**Type:** `object`<br/>|
 | `internal.network.vnet` | **VNet spec** - Existing VNet configuration. This is susceptible to more frequent change or removal.|**Type:** `object`<br/>**Default:** `{}`|
 | `internal.network.vnet.name` | **VNet name** - Name of the existing VNet.|**Type:** `string`<br/>**Value pattern:** `^[-\w\._]+$`<br/>|

--- a/helm/cluster-azure/templates/list.yaml
+++ b/helm/cluster-azure/templates/list.yaml
@@ -1,8 +1,3 @@
-{{- if semverCompare "<1.25.0" .Values.internal.kubernetesVersion -}}
----
-{{- include "psps" . }}
-{{- end }}
----
 {{- include "azure-cluster" . }}
 ---
 {{- include "containerd-config-secret" . }}

--- a/helm/cluster-azure/values.schema.json
+++ b/helm/cluster-azure/values.schema.json
@@ -1482,34 +1482,6 @@
                     "title": "Enable VPA Resources in helmreleases",
                     "default": true
                 },
-                "kubectlImage": {
-                    "type": "object",
-                    "title": "Kubectl Image settings",
-                    "properties": {
-                        "name": {
-                            "type": "string",
-                            "title": "Image name",
-                            "description": "Name of the image Registry",
-                            "default": "giantswarm/kubectl"
-                        },
-                        "registry": {
-                            "type": "string",
-                            "title": "Kubectl Image Registry",
-                            "description": "Registry for the kubectl image",
-                            "default": "gsoci.azurecr.io"
-                        },
-                        "tag": {
-                            "type": "string",
-                            "title": "Image tag",
-                            "default": "1.25.15"
-                        }
-                    }
-                },
-                "kubernetesVersion": {
-                    "type": "string",
-                    "title": "Kubernetes version",
-                    "default": "1.25.16"
-                },
                 "network": {
                     "type": "object",
                     "title": "Network configuration",

--- a/helm/cluster-azure/values.yaml
+++ b/helm/cluster-azure/values.yaml
@@ -274,11 +274,6 @@ internal:
     softEvictionGracePeriod: memory.available=30s,nodefs.available=2m,nodefs.inodesFree=1m,imagefs.available=2m,pid.available=1m
     softEvictionThresholds: memory.available<500Mi,nodefs.available<15%,nodefs.inodesFree<5%,imagefs.available<15%,pid.available<30%
   enableVpaResources: true
-  kubectlImage:
-    name: giantswarm/kubectl
-    registry: gsoci.azurecr.io
-    tag: 1.25.15
-  kubernetesVersion: 1.25.16
   network:
     vnet: {}
     vpn:


### PR DESCRIPTION
### What this PR does / why we need it

Unused values, can be dropped.

Towards: https://github.com/giantswarm/roadmap/issues/3670


### Checklist

- [x] Updated CHANGELOG.md.

### Trigger E2E tests

<!--
If you want to skip the E2E tests, remove the following line and add the `skip/ci` label to skip the check.

Note: Tests are not automatically executed when creating a draft PR. If you do want to trigger the tests while still in draft then please add a comment with the trigger.
-->

/run cluster-test-suites

<!-- If you want to disable Helm template rendering diffs as GitHub comment, uncomment this (command must be on its own line): -->

<!-- /no_diffs_printing -->