### PR TITLE
remove Cilium app deprecated values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Chart: Update `cluster` to [v1.3.0](https://github.com/giantswarm/cluster/releases/tag/v1.3.0)
   - Allow to enable auditd service through `global.components.auditd.enabled`.
 
+### Removed
+
+- Remove Cilium deprecated values.
+
 ## [1.2.0] - 2024-09-05
 
 ### Changed

--- a/helm/cluster-azure/templates/_cilium_helmrelease_config.yaml
+++ b/helm/cluster-azure/templates/_cilium_helmrelease_config.yaml
@@ -9,16 +9,6 @@ kubeProxyReplacement: strict
 hubble:
   relay:
     enabled: true
-defaultPolicies:
-  remove: true
-  enabled: false
-  tolerations:
-    - effect: NoSchedule
-      operator: Exists
-    - effect: NoExecute
-      operator: Exists
-    - key: CriticalAddonsOnly
-      operator: Exists
 global:
   podSecurityStandards:
     enforced: {{ .Values.global.podSecurityStandards.enforced }}


### PR DESCRIPTION
Signed-off-by: Matias Charriere <matias@giantswarm.io>

### What this PR does / why we need it

- Remove Cilium app deprecated values.

Towards https://github.com/giantswarm/roadmap/issues/3416

### Checklist

- [x] Updated CHANGELOG.md.

### Trigger E2E tests

<!--
If you want to skip the E2E tests, remove the following line and add the `skip/ci` label to skip the check.

Note: Tests are not automatically executed when creating a draft PR. If you do want to trigger the tests while still in draft then please add a comment with the trigger.
-->

/run cluster-test-suites

<!-- If you want to disable Helm template rendering diffs as GitHub comment, uncomment this (command must be on its own line): -->

<!-- /no_diffs_printing -->
