### PR TITLE
Chart: Update `cluster` to v1.4.1.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Chart: Update `cluster` to [v1.3.0](https://github.com/giantswarm/cluster/releases/tag/v1.3.0)
+- Chart: Update `cluster` to [v1.4.1](https://github.com/giantswarm/cluster/releases/tag/v1.4.1)
   - Allow to enable auditd service through `global.components.auditd.enabled`.
+  - Allow configuring `kube-controller-manager` `--node-cidr-mask-size` flag.
 
 ### Removed
 

--- a/helm/cluster-azure/Chart.lock
+++ b/helm/cluster-azure/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: cluster
   repository: https://giantswarm.github.io/cluster-catalog
-  version: 1.3.0
+  version: 1.4.1
 - name: cluster-shared
   repository: https://giantswarm.github.io/cluster-catalog
   version: 0.7.1
-digest: sha256:24f46006c543e98d09f258d6995dc77277f5bcf74520b0b145280d349cfd219e
-generated: "2024-09-06T13:54:00.14967+02:00"
+digest: sha256:346980c7aeada3705103241a499bc0b7246dda23aae74fee2956fc6f820e3fd0
+generated: "2024-09-24T15:00:51.15775+02:00"

--- a/helm/cluster-azure/Chart.yaml
+++ b/helm/cluster-azure/Chart.yaml
@@ -12,7 +12,7 @@ annotations:
   application.giantswarm.io/team: phoenix
 dependencies:
   - name: cluster
-    version: "1.3.0"
+    version: "1.4.1"
     repository: https://giantswarm.github.io/cluster-catalog
   - name: cluster-shared
     version: "0.7.1"

--- a/helm/cluster-azure/README.md
+++ b/helm/cluster-azure/README.md
@@ -245,7 +245,7 @@ Advanced configuration of components that are running on all nodes.
 | **Property** | **Description** | **More Details** |
 | :----------- | :-------------- | :--------------- |
 | `global.components.auditd` | **Auditd** - Enable Auditd service.|**Type:** `object`<br/>|
-| `global.components.auditd.enabled` | **Enabled** - Whether or not the Auditd service shall be enabled. When true, the Auditd service is enabled. When false, the Auditd rules service is disabled.|**Type:** `boolean`<br/>**Default:** `false`|
+| `global.components.auditd.enabled` | **Enabled** - Whether or not the Auditd service shall be enabled. When true, the Auditd service is enabled. When false, the Auditd service is disabled.|**Type:** `boolean`<br/>**Default:** `false`|
 | `global.components.containerd` | **Containerd** - Configuration of containerd.|**Type:** `object`<br/>|
 | `global.components.containerd.containerRegistries` | **Container registries** - Endpoints and credentials configuration for container registries.|**Type:** `object`<br/>**Default:** `{"docker.io":[{"endpoint":"registry-1.docker.io"},{"endpoint":"giantswarm.azurecr.io"}],"gsoci.azurecr.io":[{"endpoint":"gsoci.azurecr.io"}]}`|
 | `global.components.containerd.containerRegistries.*` | **Registries** - Container registries and mirrors|**Type:** `array`<br/>|
@@ -300,6 +300,7 @@ Properties within the `.global.connectivity` object
 | `global.connectivity.network.pods` | **Pods**|**Type:** `object`<br/>|
 | `global.connectivity.network.pods.cidrBlocks` | **Pod subnets**|**Type:** `array`<br/>**Default:** `["192.168.0.0/16"]`|
 | `global.connectivity.network.pods.cidrBlocks[*]` | **Pod subnet** - IPv4 address range for pods, in CIDR notation.|**Type:** `string`<br/>**Example:** `"192.168.0.0/16"`<br/>|
+| `global.connectivity.network.pods.nodeCidrMaskSize` | **Node CIDR mask size** - The size of the mask that is used for the node CIDR. The node CIDR is a sub-range of the pod CIDR and so the mask size and pod CIDR must be chosen such that there is enough space for the maximum number of nodes in the cluster.|**Type:** `integer`<br/>**Default:** `24`|
 | `global.connectivity.network.services` | **Services**|**Type:** `object`<br/>|
 | `global.connectivity.network.services.cidrBlocks` | **K8s Service subnets**|**Type:** `array`<br/>**Default:** `["172.31.0.0/16"]`|
 | `global.connectivity.network.services.cidrBlocks[*]` | **Service subnet** - IPv4 address range for kubernetes services, in CIDR notation.|**Type:** `string`<br/>**Example:** `"172.31.0.0/16"`<br/>|

--- a/helm/cluster-azure/ci/test-wc-auditd-values.yaml
+++ b/helm/cluster-azure/ci/test-wc-auditd-values.yaml
@@ -1,0 +1,20 @@
+global:
+  metadata:
+    name: test-wc-minimal
+    organization: test
+    preventDeletion: false
+    servicePriority: lowest
+  components:
+    auditd:
+      enabled: true
+  providerSpecific:
+    location: "westeurope"
+    subscriptionId: 12345678-abcd-1234-abcd-1234567abcde
+  release:
+    version: v25.0.0
+
+cluster:
+  internal:
+    ephemeralConfiguration:
+      offlineTesting:
+        renderWithoutReleaseResource: true

--- a/helm/cluster-azure/ci/test-wc-node-cidr-mask-size-values.yaml
+++ b/helm/cluster-azure/ci/test-wc-node-cidr-mask-size-values.yaml
@@ -1,0 +1,21 @@
+global:
+  metadata:
+    name: test-wc-minimal
+    organization: test
+    preventDeletion: false
+    servicePriority: lowest
+  connectivity:
+    network:
+      pods:
+        nodeCidrMaskSize: 18
+  providerSpecific:
+    location: "westeurope"
+    subscriptionId: 12345678-abcd-1234-abcd-1234567abcde
+  release:
+    version: v25.0.0
+
+cluster:
+  internal:
+    ephemeralConfiguration:
+      offlineTesting:
+        renderWithoutReleaseResource: true

--- a/helm/cluster-azure/values.schema.json
+++ b/helm/cluster-azure/values.schema.json
@@ -651,7 +651,7 @@
                                 "enabled": {
                                     "type": "boolean",
                                     "title": "Enabled",
-                                    "description": "Whether or not the Auditd service shall be enabled. When true, the Auditd service is enabled. When false, the Auditd rules service is disabled.",
+                                    "description": "Whether or not the Auditd service shall be enabled. When true, the Auditd service is enabled. When false, the Auditd service is disabled.",
                                     "default": false
                                 }
                             }
@@ -979,6 +979,14 @@
                                             ],
                                             "maxItems": 1,
                                             "minItems": 1
+                                        },
+                                        "nodeCidrMaskSize": {
+                                            "type": "integer",
+                                            "title": "Node CIDR mask size",
+                                            "description": "The size of the mask that is used for the node CIDR. The node CIDR is a sub-range of the pod CIDR and so the mask size and pod CIDR must be chosen such that there is enough space for the maximum number of nodes in the cluster.",
+                                            "default": 24,
+                                            "maximum": 27,
+                                            "minimum": 16
                                         }
                                     }
                                 },

--- a/helm/cluster-azure/values.yaml
+++ b/helm/cluster-azure/values.yaml
@@ -231,6 +231,7 @@ global:
       pods:
         cidrBlocks:
           - 192.168.0.0/16
+        nodeCidrMaskSize: 24
       services:
         cidrBlocks:
           - 172.31.0.0/16


### PR DESCRIPTION
### What this PR does / why we need it

This PR updates the `cluster` chart to v1.4.1 and implements new properties included in it.

### Checklist

- [x] Updated CHANGELOG.md.

### Trigger E2E tests

<!--
If you want to skip the E2E tests, remove the following line and add the `skip/ci` label to skip the check.

Note: Tests are not automatically executed when creating a draft PR. If you do want to trigger the tests while still in draft then please add a comment with the trigger.

Full docs and all optional params can be found at: https://github.com/giantswarm/cluster-test-suites#%EF%B8%8F-running-tests-in-ci
-->

/run cluster-test-suites

<!-- If you want to disable Helm template rendering diffs as GitHub comment, uncomment this (command must be on its own line): -->

<!-- /no_diffs_printing -->
