### PR TITLE
external-dns-private should depend on prometheus-operator-crd app due to ServiceMonitors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Make `external-dns-private` app depend on the `prometheus-operator-crd` app, because it uses `ServiceMonitors`.
+
 ## [1.3.0] - 2024-09-24
 
 ### Changed

--- a/helm/cluster-azure/templates/externaldns_private_app.yaml
+++ b/helm/cluster-azure/templates/externaldns_private_app.yaml
@@ -29,6 +29,8 @@ metadata:
   labels:
     {{- include "labels.common" . | nindent 4 }}
     giantswarm.io/managed-by: {{ .Chart.Name }}
+  annotations:
+    app-operator.giantswarm.io/depends-on: {{ include "resource.default.name" . }}-prometheus-operator-crd
 spec:
   {{- $_ := set $ "appName" "external-dns" }}
   catalog: {{ include "cluster.app.catalog" $ }}


### PR DESCRIPTION
### What this PR does / why we need it

Towards https://github.com/giantswarm/roadmap/issues/3720

### Checklist

- [X] Updated CHANGELOG.md.

### Trigger E2E tests

<!--
If you want to skip the E2E tests, remove the following line and add the `skip/ci` label to skip the check.

Note: Tests are not automatically executed when creating a draft PR. If you do want to trigger the tests while still in draft then please add a comment with the trigger.

Full docs and all optional params can be found at: https://github.com/giantswarm/cluster-test-suites#%EF%B8%8F-running-tests-in-ci
-->

/run cluster-test-suites

<!-- If you want to disable Helm template rendering diffs as GitHub comment, uncomment this (command must be on its own line): -->

<!-- /no_diffs_printing -->
