### PR TITLE
use workload identity by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Use azure workload identity by default.
+
 ## [2.2.0] - 2025-06-03
 
 ### Changed

--- a/helm/cluster-azure/README.md
+++ b/helm/cluster-azure/README.md
@@ -225,7 +225,7 @@ Properties within the `.global.providerSpecific` object
 | `global.providerSpecific.allowedSubscriptions` | **List of Azure Subscription IDs that are allowed to work on this cluster**|**Type:** `array`<br/>**Default:** `[]`|
 | `global.providerSpecific.allowedSubscriptions[*]` | **Azure Subscription ID**|**Type:** `string`<br/>**Example:** `"291bba3f-e0a5-47bc-a099-3bdcb2a50a05"`<br/>**Value pattern:** `^[a-fA-F0-9][-a-fA-F0-9]+[a-fA-F0-9]$`<br/>|
 | `global.providerSpecific.azureClusterIdentity` | **Identity** - AzureClusterIdentity resource to use for this cluster.|**Type:** `object`<br/>|
-| `global.providerSpecific.azureClusterIdentity.name` | **Name**|**Type:** `string`<br/>**Default:** `"cluster-identity"`|
+| `global.providerSpecific.azureClusterIdentity.name` | **Name**|**Type:** `string`<br/>**Default:** `"cluster-workload-identity"`|
 | `global.providerSpecific.azureClusterIdentity.namespace` | **Namespace**|**Type:** `string`<br/>**Default:** `"org-giantswarm"`|
 | `global.providerSpecific.identity` | **Identity**|**Type:** `object`<br/>|
 | `global.providerSpecific.identity.systemAssignedScope` | **Scope of SystemAssignedIdentity**|**Type:** `string`<br/>**Default:** `"ResourceGroup"`|

--- a/helm/cluster-azure/values.schema.json
+++ b/helm/cluster-azure/values.schema.json
@@ -1365,7 +1365,7 @@
                                 "name": {
                                     "type": "string",
                                     "title": "Name",
-                                    "default": "cluster-identity"
+                                    "default": "cluster-workload-identity"
                                 },
                                 "namespace": {
                                     "type": "string",

--- a/helm/cluster-azure/values.yaml
+++ b/helm/cluster-azure/values.yaml
@@ -262,7 +262,7 @@ global:
     additionalResourceTags: {}
     allowedSubscriptions: []
     azureClusterIdentity:
-      name: cluster-identity
+      name: cluster-workload-identity
       namespace: org-giantswarm
     identity:
       systemAssignedScope: ResourceGroup


### PR DESCRIPTION
This should only be released when MCs are migrated

### What this PR does / why we need it



### Checklist

- [ ] Updated CHANGELOG.md.

### Trigger E2E tests

<!--
If you want to skip the E2E tests, remove the following line and add the `skip/ci` label to skip the check.

Note: Tests are not automatically executed when creating a draft PR. If you do want to trigger the tests while still in draft then please add a comment with the trigger.

Full docs and all optional params can be found at: https://github.com/giantswarm/cluster-test-suites#%EF%B8%8F-running-tests-in-ci
-->

/run cluster-test-suites

<!-- If you want to disable Helm template rendering diffs as GitHub comment, uncomment this (command must be on its own line): -->

<!-- /no_diffs_printing -->
