### PR TITLE
Remove custom cilium configuration overrides

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Remove custom cilium configuration overrides
+
 ## [2.2.0] - 2025-06-03
 
 ### Changed

--- a/helm/cluster-azure/templates/_cilium_helmrelease_config.yaml
+++ b/helm/cluster-azure/templates/_cilium_helmrelease_config.yaml
@@ -1,15 +1,4 @@
 {{/* Azure-specific cilium Helm values*/}}
 {{/* https://github.com/giantswarm/cilium-app/blob/main/helm/cilium/values.yaml*/}}
 {{- define "azureCiliumHelmValues" }}
-ipam:
-  mode: kubernetes
-k8sServiceHost: apiserver.{{ include "resource.default.name" $ }}.{{ .Values.global.connectivity.baseDomain }}
-k8sServicePort: '6443'
-kubeProxyReplacement: strict
-hubble:
-  relay:
-    enabled: true
-global:
-  podSecurityStandards:
-    enforced: {{ .Values.global.podSecurityStandards.enforced }}
 {{- end }}


### PR DESCRIPTION
### What this PR does / why we need it

These overrides are leftovers and we can rely on the config set in cluster chart

### Checklist

- [x] Updated CHANGELOG.md.

### Trigger E2E tests

<!--
If you want to skip the E2E tests, remove the following line and add the `skip/ci` label to skip the check.

Note: Tests are not automatically executed when creating a draft PR. If you do want to trigger the tests while still in draft then please add a comment with the trigger.

Full docs and all optional params can be found at: https://github.com/giantswarm/cluster-test-suites#%EF%B8%8F-running-tests-in-ci
-->

/run cluster-test-suites

<!-- If you want to disable Helm template rendering diffs as GitHub comment, uncomment this (command must be on its own line): -->

<!-- /no_diffs_printing -->
