### PR TITLE
feat(cert-manager): enable DNS challenges by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Enable cert-manager DNS challenges by default.
+
 ## [6.6.0] - 2026-06-02
 
 ### Changed

--- a/helm/cluster-azure/README.md
+++ b/helm/cluster-azure/README.md
@@ -342,7 +342,7 @@ Properties within the `.global.connectivity` object
 | `global.connectivity.allowedCIDRs[*]` |**None**|**Type:** `string`<br/>|
 | `global.connectivity.baseDomain` | **Base DNS domain**|**Type:** `string`<br/>**Default:** `"azuretest.gigantic.io"`|
 | `global.connectivity.certManager` | **CertManager** - Configuration of CertManager.|**Type:** `object`<br/>|
-| `global.connectivity.certManager.useDnsChallenges` | **Use DNS Challenges** - Set to true to enable DNS challenges in the default ClusterIssuer.|**Type:** `boolean`<br/>**Default:** `false`|
+| `global.connectivity.certManager.useDnsChallenges` | **Use DNS Challenges** - Set to true to enable DNS challenges in the default ClusterIssuer.|**Type:** `boolean`<br/>**Default:** `true`|
 | `global.connectivity.dns` | **DNS**|**Type:** `object`<br/>|
 | `global.connectivity.dns.wildcardCnameTarget` | **Wildcard CNAME Target** - Override the wildcard CNAME record value. If no value is passed defaults to "ingress". Only subdomains from the cluster DNS zone are valid.|**Type:** `string`<br/>**Example:** `"gateway"`<br/>|
 | `global.connectivity.network` | **Network**|**Type:** `object`<br/>|

--- a/helm/cluster-azure/values.schema.json
+++ b/helm/cluster-azure/values.schema.json
@@ -1008,7 +1008,7 @@
                                     "type": "boolean",
                                     "title": "Use DNS Challenges",
                                     "description": "Set to true to enable DNS challenges in the default ClusterIssuer.",
-                                    "default": false
+                                    "default": true
                                 }
                             }
                         },

--- a/helm/cluster-azure/values.yaml
+++ b/helm/cluster-azure/values.yaml
@@ -253,7 +253,7 @@ global:
     allowedCIDRs: []
     baseDomain: azuretest.gigantic.io
     certManager:
-      useDnsChallenges: false
+      useDnsChallenges: true
     dns: {}
     network:
       controlPlane:


### PR DESCRIPTION
## Summary

- Set `useDnsChallenges` default to `true` in `values.yaml` and `values.schema.json`
- Update generated `README.md` and `CHANGELOG.md` accordingly

Towards https://github.com/giantswarm/roadmap/issues/4209

## Test plan

- [ ] Verify new clusters use DNS challenges for the `letsencrypt-giantswarm` ClusterIssuer by default
- [ ] Verify existing clusters with `useDnsChallenges: false` explicitly set are not affected