### PR TITLE
Bump cluster subchart to dev version from PR #780

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Chart: Bump `cluster` subchart to dev version `6.6.0-07c04f97c073fe231b1b5912fcdfbefd39526338` from [giantswarm/cluster#780](https://github.com/giantswarm/cluster/pull/780), pulled from `cluster-test-catalog` to pick up the App → HelmRelease migration changes.
+
 ## [6.5.0] - 2026-05-20
 
 ### Changed

--- a/helm/cluster-azure/Chart.lock
+++ b/helm/cluster-azure/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: cluster
-  repository: https://giantswarm.github.io/cluster-catalog
-  version: 6.5.0
-digest: sha256:91656ace56a7d1c5b2f85c90b67a2204ec4ad462339a2b5c3fa93c3bae956e73
-generated: "2026-05-20T13:52:05.764518739Z"
+  repository: https://giantswarm.github.io/cluster-test-catalog
+  version: 6.6.0-07c04f97c073fe231b1b5912fcdfbefd39526338
+digest: sha256:78aa2a9da32ea3821a1b08738783574763662302a893f2fe7ec690ad59b635f7
+generated: "2026-06-01T16:15:25.978344+02:00"

--- a/helm/cluster-azure/Chart.yaml
+++ b/helm/cluster-azure/Chart.yaml
@@ -12,5 +12,5 @@ annotations:
   application.giantswarm.io/team: phoenix
 dependencies:
   - name: cluster
-    repository: https://giantswarm.github.io/cluster-catalog
-    version: "6.5.0"
+    repository: https://giantswarm.github.io/cluster-test-catalog
+    version: "6.6.0-07c04f97c073fe231b1b5912fcdfbefd39526338"


### PR DESCRIPTION
## Summary

- Bumps the `cluster` subchart dependency from `6.5.0` (cluster-catalog) to the dev build `6.6.0-07c04f97c073fe231b1b5912fcdfbefd39526338` from [giantswarm/cluster#780](https://github.com/giantswarm/cluster/pull/780), pulled from `cluster-test-catalog`.
- Picks up the App → HelmRelease migration changes so cluster-azure can be validated end-to-end against them before the upstream PR is merged and a stable `cluster` release is cut.

**Do not merge** while the upstream PR is still labelled "Do not merge yet" — the subchart points at a non-release dev artifact.

## Test plan

- [ ] `helm dependency update` succeeds and `Chart.lock` matches `Chart.yaml`.
- [ ] `helm template helm/cluster-azure` renders without errors against a representative values file.
- [ ] Render diff against `main` to confirm the only differences are the expected App → HelmRelease swaps and the migration hook resources.
- [ ] e2e: create a workload cluster with this chart and verify default apps end up as HelmReleases (no `App` CRs in the cluster namespace beyond what the migration hook expects).