### PR TITLE
chore: migrate cert-manager values for v4.0.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Updated `cert-manager` to v4.0.0 and migrated the values to match the new chart's schema.
+
 ## [6.7.0] - 2026-06-18
 
 ### Changed
@@ -310,13 +314,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <details>
 <summary>How to migrate to cluster-azure</summary>
 
-* In ConfigMap `<cluster name>-userconfig` set `.Values.global.release` to the release version, e.g. `25.0.0`. 
+* In ConfigMap `<cluster name>-userconfig` set `.Values.global.release` to the release version, e.g. `25.0.0`.
 * In App `<cluster name>` set the `version` to an empty string.
 </details>
-  
+
 ## [0.16.1] - 2024-07-16
 
-### Changed 
+### Changed
 
 - Respect `global.apps.externalDnsPrivate` to overwrite configuration of `external-dns-private` app.
 
@@ -368,9 +372,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <details>
 <summary>How to migrate to cluster-azure v0.14.0</summary>
 
-* Update `<cluster name>` to the latest version of `default-apps-azure` (v0.14.0). 
-* In ConfigMap `<cluster name>-default-apps-userconfig` set `.Values.deleteOptions.moveAppsHelmOwnershipToClusterAzure` to `true`. 
-* Delete `<cluster name>-default-apps` App. 
+* Update `<cluster name>` to the latest version of `default-apps-azure` (v0.14.0).
+* In ConfigMap `<cluster name>-default-apps-userconfig` set `.Values.deleteOptions.moveAppsHelmOwnershipToClusterAzure` to `true`.
+* Delete `<cluster name>-default-apps` App.
 * Update `<cluster name>` to the latest version of `cluster-azure` (v0.14.0).
 
 </details>

--- a/helm/cluster-azure/templates/_certmanager_app_config.yaml
+++ b/helm/cluster-azure/templates/_certmanager_app_config.yaml
@@ -9,11 +9,14 @@
 
 # check extra config for private WC parameters
 # note that user config has higher priority and extra config can be overwritten by userConfig
-dns01RecursiveNameserversOnly: true
+cert-manager:
+  dns01RecursiveNameserversOnly: true
+{{- if (include "useCertManagerDnsChallenges" $ | eq "true") }}
+  dns01RecursiveNameservers: "8.8.8.8:53,1.1.1.1:53"
+{{- end }}
 ciliumNetworkPolicy:
   enabled: true
 {{- if (include "useCertManagerDnsChallenges" $ | eq "true") }}
-dns01RecursiveNameservers: "8.8.8.8:53,1.1.1.1:53"
 giantSwarmClusterIssuer:
   acme:
     http01:


### PR DESCRIPTION
> [!WARNING]
> This PR depends on the v4.0.1 cert-manager release:
> https://github.com/giantswarm/cert-manager-app/releases/tag/v4.0.1

`cert-manager` now vendors upstream `cert-manager` as a subchart, so its upstream values live under a `cert-manager`: key. The values we pass to `cert-manager-app` from the cluster charts need to move accordingly.

Towards: https://github.com/giantswarm/giantswarm/issues/36890

