### PR TITLE
fix: set default for nodepool's encryptionAtHost parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Set default for nodepool's `encryptionAtHost` parameter to `false`.
+
 ## [6.7.0] - 2026-06-18
 
 ### Changed

--- a/helm/cluster-azure/templates/_machine_helpers.tpl
+++ b/helm/cluster-azure/templates/_machine_helpers.tpl
@@ -21,7 +21,7 @@ osDisk:
     storageAccountType: Premium_LRS
   osType: Linux
 securityProfile:
-  encryptionAtHost: {{ .nodePool.config.encryptionAtHost }}
+  encryptionAtHost: {{ .nodePool.config.encryptionAtHost | default false }}
 sshPublicKey: {{ include "fake-rsa-ssh-key" $ | b64enc }}
 vmSize: {{ .nodePool.config.instanceType | default "Standard_D4s_v5" }}
 {{- if ( include "network.subnets.nodes.name" $ ) }}


### PR DESCRIPTION
### What this PR does / why we need it

Sets the same default as the CRD. Required for server-side-apply as it rejects a null value.

### Checklist

- [x] Updated CHANGELOG.md.

### Trigger E2E tests

<!--
If you want to skip the E2E tests, remove the following line and add the `skip/ci` label to skip the check.

Note: Tests are not automatically executed when creating a draft PR. If you do want to trigger the tests while still in draft then please add a comment with the trigger.

Full docs and all optional params can be found at: https://github.com/giantswarm/cluster-test-suites#%EF%B8%8F-running-tests-in-ci
-->

/run cluster-test-suites

<!-- If you want to disable Helm template rendering diffs as GitHub comment, uncomment this (command must be on its own line): -->

<!-- /no_diffs_printing -->
