### PR TITLE
fix: Migrate HelmRelease resources from removed helm.toolkit.fluxcd.io/v2beta1 to v2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Bump `HelmRelease` resources from the removed `helm.toolkit.fluxcd.io/v2beta1` API to `helm.toolkit.fluxcd.io/v2` so cluster apps render on management clusters running current Flux.
+
 ### Removed
 
 - coredns: Drop the provider-specific values override now covered by the shared `cluster` chart defaults.

--- a/helm/cluster-azure/templates/azure-cloud-controller-manager-helmrelease.yaml
+++ b/helm/cluster-azure/templates/azure-cloud-controller-manager-helmrelease.yaml
@@ -13,7 +13,7 @@ global:
   podSecurityStandards:
     enforced: {{ .Values.global.podSecurityStandards.enforced }}
 {{- end }}
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: {{ include "resource.default.name" $ }}-azure-cloud-controller-manager

--- a/helm/cluster-azure/templates/azure-cloud-node-manager-helmrelease.yaml
+++ b/helm/cluster-azure/templates/azure-cloud-node-manager-helmrelease.yaml
@@ -9,7 +9,7 @@ global:
 # kyverno installs PolicyException CRs for core components on CAPI clusters
 deployPolicyExceptions: false
 {{- end }}
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: {{ include "resource.default.name" $ }}-azure-cloud-node-manager

--- a/helm/cluster-azure/templates/azuredisk-csi-driver-helmrelease.yaml
+++ b/helm/cluster-azure/templates/azuredisk-csi-driver-helmrelease.yaml
@@ -24,7 +24,7 @@ cluster:
     https: {{ .Values.global.connectivity.proxy.httpsProxy | quote }}
 {{- end }}
 {{- end }}
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: {{ include "resource.default.name" $ }}-azuredisk-csi-driver

--- a/helm/cluster-azure/templates/azurefile-csi-driver-helmrelease.yaml
+++ b/helm/cluster-azure/templates/azurefile-csi-driver-helmrelease.yaml
@@ -13,7 +13,7 @@ cluster:
     https: {{ .Values.global.connectivity.proxy.httpsProxy | quote }}
 {{- end }}
 {{- end }}
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: {{ include "resource.default.name" $ }}-azurefile-csi-driver

--- a/helm/cluster-azure/templates/externaldns_private_app.yaml
+++ b/helm/cluster-azure/templates/externaldns_private_app.yaml
@@ -1,6 +1,6 @@
 {{/* Azure-specific external-dns app for private clusters */}}
 {{- if eq .Values.global.connectivity.network.mode "private" }}
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: {{ include "resource.default.name" $ }}-external-dns-private


### PR DESCRIPTION
The CAPZ E2E `BeforeSuite` for release `34.5.0` timed out because the Cluster App failed to render:

```
ReleaseStatus='invalid-manifest'
no matches for kind "HelmRelease" in version "helm.toolkit.fluxcd.io/v2beta1"
```

The management cluster runs a Flux version that no longer serves `helm.toolkit.fluxcd.io/v2beta1` (only `v2` and `v2beta2` are available). This bumps all `HelmRelease` resources in `cluster-azure` to `helm.toolkit.fluxcd.io/v2`, matching what `cluster-aws` already uses. All spec fields are unchanged in the GA API.

Affected templates:
- `azure-cloud-controller-manager-helmrelease.yaml`
- `azure-cloud-node-manager-helmrelease.yaml`
- `azuredisk-csi-driver-helmrelease.yaml`
- `azurefile-csi-driver-helmrelease.yaml`
- `externaldns_private_app.yaml`
