### PR TITLE
fix: Migrate to new location of deprecated `subnetName` field in `AzureMachineTemplate`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Migrate to new location of deprecated `subnetName` field in `AzureMachineTemplate` by nesting it under `networkInterfaces`, and drop the always-true conditionals around it. Since the field is part of the hashed `AzureMachineTemplate` spec, the resource is renamed and control plane and worker nodes are rolled.
+
 ### Removed
 
 - coredns: Drop the provider-specific values override now covered by the shared `cluster` chart defaults.
@@ -327,13 +331,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <details>
 <summary>How to migrate to cluster-azure</summary>
 
-* In ConfigMap `<cluster name>-userconfig` set `.Values.global.release` to the release version, e.g. `25.0.0`. 
+* In ConfigMap `<cluster name>-userconfig` set `.Values.global.release` to the release version, e.g. `25.0.0`.
 * In App `<cluster name>` set the `version` to an empty string.
 </details>
-  
+
 ## [0.16.1] - 2024-07-16
 
-### Changed 
+### Changed
 
 - Respect `global.apps.externalDnsPrivate` to overwrite configuration of `external-dns-private` app.
 
@@ -385,9 +389,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <details>
 <summary>How to migrate to cluster-azure v0.14.0</summary>
 
-* Update `<cluster name>` to the latest version of `default-apps-azure` (v0.14.0). 
-* In ConfigMap `<cluster name>-default-apps-userconfig` set `.Values.deleteOptions.moveAppsHelmOwnershipToClusterAzure` to `true`. 
-* Delete `<cluster name>-default-apps` App. 
+* Update `<cluster name>` to the latest version of `default-apps-azure` (v0.14.0).
+* In ConfigMap `<cluster name>-default-apps-userconfig` set `.Values.deleteOptions.moveAppsHelmOwnershipToClusterAzure` to `true`.
+* Delete `<cluster name>-default-apps` App.
 * Update `<cluster name>` to the latest version of `cluster-azure` (v0.14.0).
 
 </details>

--- a/helm/cluster-azure/templates/_kcp.tpl
+++ b/helm/cluster-azure/templates/_kcp.tpl
@@ -29,9 +29,8 @@ securityProfile:
   encryptionAtHost: {{ $.Values.global.controlPlane.encryptionAtHost }}
 sshPublicKey: {{ include "fake-rsa-ssh-key" $ | b64enc }}
 vmSize: {{ $.Values.global.controlPlane.instanceType }}
-{{- if ( include "network.subnets.controlPlane.name" $ ) }}
-subnetName: {{ include "network.subnets.controlPlane.name" $ }}
-{{- end }}
+networkInterfaces:
+  - subnetName: {{ include "network.subnets.controlPlane.name" $ | quote }}
 {{- end }}
 
 {{- define "control-plane" }}

--- a/helm/cluster-azure/templates/_machine_helpers.tpl
+++ b/helm/cluster-azure/templates/_machine_helpers.tpl
@@ -24,9 +24,8 @@ securityProfile:
   encryptionAtHost: {{ .nodePool.config.encryptionAtHost | default false }}
 sshPublicKey: {{ include "fake-rsa-ssh-key" $ | b64enc }}
 vmSize: {{ .nodePool.config.instanceType | default "Standard_D4s_v5" }}
-{{- if ( include "network.subnets.nodes.name" $ ) }}
-subnetName: {{ include "network.subnets.nodes.name" $ }}
-{{- end }}
+networkInterfaces:
+  - subnetName: {{ include "network.subnets.nodes.name" $ | quote }}
 {{- end -}}
 
 {{- define "machine-kubeadmconfig-spec" -}}


### PR DESCRIPTION
### What this PR does / why we need it

I had trouble where `spec` using the old field location couldn't be updated. That location is deprecated, so let's use the new one. Rolls nodes.

### Checklist

- [x] Updated CHANGELOG.md.

### Trigger E2E tests

<!--
If you want to skip the E2E tests, remove the following line and add the `skip/ci` label to skip the check.

Note: Tests are not automatically executed when creating a draft PR. If you do want to trigger the tests while still in draft then please add a comment with the trigger.

Full docs and all optional params can be found at: https://github.com/giantswarm/cluster-test-suites#%EF%B8%8F-running-tests-in-ci
-->

/run cluster-test-suites

<!-- If you want to disable Helm template rendering diffs as GitHub comment, uncomment this (command must be on its own line): -->

<!-- /no_diffs_printing -->
